### PR TITLE
Feilrettinger etter kjøring i prod.

### DIFF
--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/service/SafService.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/service/SafService.kt
@@ -27,9 +27,14 @@ class SafService(val safApi: SafInterface) {
 			}
 
 		logger.info("Hentet ${innsendte.size} journalposter for bruker, skal mappe til AktivSakDto")
-		logger.info("Hentet ${innsendte.forEach { it.toString() }}")
-		return innsendte.map { AktivSakDto(finnBrevKode(it.dokumenter), it.tittel, it.tema,
+		val innsendteMedHovedDokMedBrevkode = innsendte.filter { harHoveddokumentMedBrevkodeSatt(it.dokumenter) }
+		logger.debug("innsendteMedHovedDokMedBrevkode ${innsendteMedHovedDokMedBrevkode.size}")
+		return innsendteMedHovedDokMedBrevkode.map { AktivSakDto(finnBrevKode(it.dokumenter), it.tittel, it.tema,
 				konverterTilDateTime(it.datoMottatt ?: ""), erEttersending(it.dokumenter), konverterTilVedleggsliste(it.dokumenter), it.eksternReferanseId ) }
+	}
+
+	private fun harHoveddokumentMedBrevkodeSatt(innsendteDokumenter: List<Dokument>): Boolean {
+		return innsendteDokumenter.count { it.k_tilkn_jp_som.equals("HOVEDDOKUMENT", true) && it.brevkode != null } > 0
 	}
 
 	private fun konverterTilDateTime(dateString: String): OffsetDateTime {

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/service/SoknadService.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/service/SoknadService.kt
@@ -1112,9 +1112,9 @@ class SoknadService(
 		if (filer.isEmpty()) return null
 
 		val vedleggsFil: ByteArray? =
-			if (vedleggDto.erHoveddokument) {
+			if (vedleggDto.erHoveddokument && vedleggDto.erVariant ) {
 				if (filer.size > 1) {
-					logger.warn("Vedlegg ${vedleggDto.id}: ${vedleggDto.tittel} har flere opplastede filer, velger første")
+					logger.warn("${soknadDto.innsendingsId}: soknadDtoVedlegg ${vedleggDto.id} erVariant${vedleggDto.erVariant} - ${vedleggDto.tittel} har flere opplastede filer, velger første")
 				}
 				filer[0].data
 			} else {


### PR DESCRIPTION
Ved opplasting av hoveddokument, så skaldet være mulig å laste opp flere filer Nullpointer ved henting av journalposter for søker via SAF dersom returnert hoveddokument mangler brevkode. Filtrerer bort alle journalposter der brevkode mangler på hoveddokument