### PR TITLE
Sjekk opplastingsstatus

### DIFF
--- a/innsender/pom.xml
+++ b/innsender/pom.xml
@@ -13,8 +13,8 @@
 	<name>innsender</name>
 
 	<properties>
-		<token-validation.version>2.0.20</token-validation.version>
-		<mock-oauth2-server.version>0.4.8</mock-oauth2-server.version>
+		<token-validation.version>2.1.7</token-validation.version>
+		<mock-oauth2-server.version>0.5.7</mock-oauth2-server.version>
 
 		<kotlin-serialization.version>1.4.1</kotlin-serialization.version>
 		<otj-pg-embedded.version>1.0.1</otj-pg-embedded.version>
@@ -329,7 +329,6 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<version>${spring-boot.version}</version>
 			</plugin>
 
 			<plugin>

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/SkjemaDokumentSoknadTransformer.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/SkjemaDokumentSoknadTransformer.kt
@@ -1,6 +1,7 @@
 package no.nav.soknad.innsending.rest
 
 import no.nav.soknad.innsending.model.*
+import no.nav.soknad.innsending.service.mapTilOffsetDateTime
 import no.nav.soknad.innsending.util.Constants
 import no.nav.soknad.innsending.util.finnSpraakFraInput
 import org.slf4j.LoggerFactory
@@ -13,7 +14,7 @@ class SkjemaDokumentSoknadTransformer {
 
 	fun konverterTilDokumentSoknadDto(input: SkjemaDto, brukerId: String): DokumentSoknadDto = DokumentSoknadDto(
 		brukerId = brukerId, skjemanr =	input.skjemanr, tittel = input.tittel, tema = input.tema, status = SoknadsStatusDto.opprettet,
-		opprettetDato =  LocalDateTime.now().atOffset(ZoneOffset.UTC), endretDato = LocalDateTime.now().atOffset(ZoneOffset.UTC),
+		opprettetDato =  mapTilOffsetDateTime(LocalDateTime.now())!!, endretDato = mapTilOffsetDateTime(LocalDateTime.now()),
 		vedleggsListe = lagVedleggsListe(input), id = null, innsendingsId = null, ettersendingsId = null, spraak = finnSpraakFraInput(input.spraak),
 		innsendtDato = null, visningsSteg = 0, visningsType = VisningsType.fyllUt,
 		kanLasteOppAnnet = input.kanLasteOppAnnet ?: input.vedleggsListe?.any { it.propertyNavn != null && it.propertyNavn == "annenDokumentasjon"},
@@ -45,6 +46,6 @@ class SkjemaDokumentSoknadTransformer {
 		VedleggDto(skjemaDokumentDto.tittel, skjemaDokumentDto.label,erHoveddokument, erVariant,
 			skjemaDokumentDto.mimetype?.equals(Mimetype.applicationSlashPdf) ?: false, skjemaDokumentDto.pakrevd,
 			if (skjemaDokumentDto.document != null) OpplastingsStatusDto.lastetOpp else OpplastingsStatusDto.ikkeValgt,
-			LocalDateTime.now().atOffset(ZoneOffset.UTC), null, skjemaDokumentDto.vedleggsnr,  skjemaDokumentDto.beskrivelse,
+			mapTilOffsetDateTime(LocalDateTime.now())!!, null, skjemaDokumentDto.vedleggsnr,  skjemaDokumentDto.beskrivelse,
 			null, skjemaDokumentDto.mimetype, skjemaDokumentDto.document,null )
 }

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/service/MappingUtils.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/service/MappingUtils.kt
@@ -25,7 +25,10 @@ fun lagVedleggDtoMedOpplastetFil(filDto: FilDto?, vedleggDto: VedleggDto) =
 
 
 private fun avledOpplastingsstatusVedInnsending(filDto: FilDto?, vedleggDto: VedleggDto): OpplastingsStatusDto {
-	if (filDto?.data != null) return OpplastingsStatusDto.lastetOpp
+	if (filDto?.data != null
+		&& (vedleggDto.opplastingsStatus == OpplastingsStatusDto.ikkeValgt || vedleggDto.opplastingsStatus == OpplastingsStatusDto.lastetOpp)) {
+		return OpplastingsStatusDto.lastetOpp
+	}
 	return when (vedleggDto.opplastingsStatus) {
 		OpplastingsStatusDto.ikkeValgt -> if (vedleggDto.erPakrevd) OpplastingsStatusDto.sendSenere else OpplastingsStatusDto.sendesIkke
 		OpplastingsStatusDto.sendesAvAndre,

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/service/SoknadService.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/service/SoknadService.kt
@@ -1090,7 +1090,7 @@ class SoknadService(
 	private fun lenkeTilDokument(innsendingsId: String, vedleggsId: Long?, filId: Long?) = if (filId == null) null else "frontend/v1/soknad/$innsendingsId/vedlegg/$vedleggsId/fil/$filId"
 
 	fun slettGamleSoknader(dagerGamle: Long, permanent: Boolean = false ) {
-		val slettFor = LocalDateTime.now().minusDays(dagerGamle).atOffset(ZoneOffset.UTC)
+		val slettFor = mapTilOffsetDateTime(LocalDateTime.now(), -dagerGamle)
 		logger.info("Finn opprettede søknader opprettet før $slettFor permanent=$permanent")
 		if (permanent) {
 			val soknadDbDataListe = repo.findAllByOpprettetdatoBefore(slettFor)

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/brukernotifikasjon/kafka/BrukernotifikasjonPublisherTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/brukernotifikasjon/kafka/BrukernotifikasjonPublisherTest.kt
@@ -32,6 +32,9 @@ internal class BrukernotifikasjonPublisherTest {
 	var sendTilPublisher = mockk<PublisherInterface>()
 
 	private var brukernotifikasjonPublisher: BrukernotifikasjonPublisher? = null
+	private val defaultSkjemanr = "NAV 55-00.60"
+	private val defaultTema = "BID"
+	private val defaultTittel = "Avtale om barnebidrag"
 
 	@BeforeEach
 	fun setUp() {
@@ -41,10 +44,10 @@ internal class BrukernotifikasjonPublisherTest {
 	@Test
 	fun `sjekk at melding for å publisere Oppgave eller Beskjed blir sendt ved oppretting av ny søknad`() {
 		val innsendingsid = "123456"
-		val skjemanr = "NAV 95-00.11"
+		val skjemanr = defaultSkjemanr
+		val tema = defaultTema
 		val spraak = "no"
 		val personId = "12125912345"
-		val tema = "PEN"
 		val tittel = "Dokumentasjon av utdanning"
 		val id = 1L
 
@@ -64,10 +67,10 @@ internal class BrukernotifikasjonPublisherTest {
 	@Test
 	fun `sjekk at melding for å publisere Done blir sendt ved innsending av søknad`() {
 		val innsendingsid = "123456"
-		val skjemanr = "NAV 95-00.11"
+		val skjemanr = defaultSkjemanr
+		val tema = defaultTema
 		val spraak = "no"
 		val personId = "12125912345"
-		val tema = "PEN"
 		val tittel = "Dokumentasjon av utdanning"
 		val id = 2L
 
@@ -86,10 +89,10 @@ internal class BrukernotifikasjonPublisherTest {
 	fun `sjekk at melding om publisering av Done og Oppgave blir sendt ved innsending av søknad med vedlegg som skal ettersendes`() {
 		val innsendingsid = "123456"
 		val ettersendingsSoknadsId = "123457"
-		val skjemanr = "NAV 95-00.11"
+		val skjemanr = defaultSkjemanr
+		val tema = defaultTema
 		val spraak = "no"
 		val personId = "12125912345"
-		val tema = "PEN"
 		val tittel = "Dokumentasjon av utdanning"
 		val id = 3L
 
@@ -132,10 +135,10 @@ internal class BrukernotifikasjonPublisherTest {
 	fun `sjekk at melding blir sendt for publisering av Done etter innsending av ettersendingssøknad`() {
 		val innsendingsid = "123456"
 		val ettersendingsSoknadsId = "123457"
-		val skjemanr = "NAV 95-00.11"
+		val skjemanr = defaultSkjemanr
+		val tema = defaultTema
 		val spraak = "no"
 		val personId = "12125912345"
-		val tema = "PEN"
 		val tittel = "Dokumentasjon av utdanning"
 		val id = 3L
 
@@ -159,11 +162,11 @@ internal class BrukernotifikasjonPublisherTest {
 	@Test
 	fun `sjekk at melding blir sendt for publisering av Done etter sletting av søknad`() {
 		val innsendingsid = "123456"
-		val skjemanr = "NAV 95-00.11"
+		val skjemanr = defaultSkjemanr
+		val tema = defaultTema
+		val tittel = defaultTittel
 		val spraak = "no"
 		val personId = "12125912345"
-		val tema = "PEN"
-		val tittel = "Dokumentasjon av utdanning"
 		val id = 2L
 
 		val done = slot<SoknadRef>()

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/rest/FrontEndRestApiTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/rest/FrontEndRestApiTest.kt
@@ -60,11 +60,14 @@ class FrontEndRestApiTest {
 	private val audience = "aud-localhost"
 	private val expiry = 2*3600
 	private val defaultUser = "12345678901"
+	private val defaultSkjemanr = "NAV 55-00.60"
+	private val defaultTema = "BID"
+	private val defaultTittel = "Avtale om barnebidrag"
 
 
 	@Test
 	fun opprettSoknadTest() {
-		val skjemanr = "NAV 95-00.11"
+		val skjemanr = defaultSkjemanr
 		val spraak = "nb_NO"
 
 		val token: String = mockOAuth2Server.issueToken(
@@ -93,7 +96,7 @@ class FrontEndRestApiTest {
 
 	@Test
 	fun hentOpprettetSoknadTest() {
-		val skjemanr = "NAV 95-00.11"
+		val skjemanr = defaultSkjemanr
 		val spraak = "nb_NO"
 
 		val token: String = mockOAuth2Server.issueToken(
@@ -131,7 +134,7 @@ class FrontEndRestApiTest {
 
 	@Test
 	fun oppdaterVedleggTest() {
-		val skjemanr = "NAV 95-00.11"
+		val skjemanr = defaultSkjemanr
 		val spraak = "nb_NO"
 		val vedlegg = listOf("N6")
 
@@ -175,7 +178,7 @@ class FrontEndRestApiTest {
 
 	@Test
 	fun sjekkOpplastingsstatusEtterOpplastingOgSlettingAvFilPaVedleggTest() {
-		val skjemanr = "NAV 95-00.11"
+		val skjemanr = defaultSkjemanr
 		val spraak = "nb_NO"
 		val vedlegg = listOf("N6", "W2")
 		val token = getToken()
@@ -222,7 +225,7 @@ class FrontEndRestApiTest {
 
 	@Test
 	fun sjekkAtOpplastingAvForStorFilGirFeilTest() {
-		val skjemanr = "NAV 95-00.11"
+		val skjemanr = defaultSkjemanr
 		val spraak = "nb_NO"
 		val vedlegg = listOf("N6", "W2")
 		val token = getToken()
@@ -256,7 +259,7 @@ class FrontEndRestApiTest {
 
 	@Test
 	fun sjekkAtOpplastingAvKryptertFilGirFeilTest() {
-		val skjemanr = "NAV 95-00.11"
+		val skjemanr = defaultSkjemanr
 		val spraak = "nb_NO"
 		val vedlegg = listOf("N6", "W2")
 		val token = getToken()
@@ -290,7 +293,7 @@ class FrontEndRestApiTest {
 
 	@Test
 	fun sjekkAtOpplastingAvUlovligFilformatGirFeilTest() {
-		val skjemanr = "NAV 95-00.11"
+		val skjemanr = defaultSkjemanr
 		val spraak = "nb_NO"
 		val vedlegg = listOf("N6", "W2")
 		val token = getToken()
@@ -364,7 +367,7 @@ class FrontEndRestApiTest {
 
 		val forventetListe = LinkedList<DokumentSoknadDto>()
 
-		forventetListe.add(opprettEnSoknad(token = token, skjemanr = "NAV 95-00.11", spraak = "nb_NO", listOf("X2")))
+		forventetListe.add(opprettEnSoknad(token = token, skjemanr = defaultSkjemanr, spraak = "nb_NO", listOf("X2")))
 		forventetListe.add(opprettEnSoknad(token = token, skjemanr = "NAV 10-07.17", spraak = "nn_NO", listOf("X2", "M3")))
 
 		if (hentetInitListe != null) {
@@ -386,7 +389,7 @@ class FrontEndRestApiTest {
 
 	@Test
 	fun oppdrettVedleggTest() {
-		val skjemanr = "NAV 95-00.11"
+		val skjemanr = defaultSkjemanr
 		val spraak = "nb_NO"
 		val vedlegg = emptyList<String>()
 

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/service/SafServiceTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/service/SafServiceTest.kt
@@ -9,6 +9,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.EnableTransactionManagement
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import kotlin.test.assertEquals
 
@@ -41,8 +42,12 @@ class SafServiceTest {
 
 	@Test
 	fun testDatoKonvertering() {
-		val dateString = LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)
 		val formatter: DateTimeFormatter = DateTimeFormatter.ISO_DATE_TIME
+		val summerDateString = "2022-08-01T12:00:00.000000"
+		val summerDateTime = LocalDateTime.parse(summerDateString, formatter)
+		val summerZoneOffset = summerDateTime.atOffset(ZoneId.of("CET").rules.getOffset(summerDateTime))
+		assertEquals("+02:00", summerZoneOffset.offset.id)
+		val dateString = LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)
 		val dateTime = LocalDateTime.parse(dateString, formatter)
 		val zoneOffSet = OffsetDateTime.now().offset
 		val dateOffset = dateTime.atOffset(zoneOffSet)

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/service/SoknadServiceTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/service/SoknadServiceTest.kt
@@ -71,6 +71,9 @@ class SoknadServiceTest {
 	@InjectMockKs
 	private val pdlInterface = mockk<PdlInterface>()
 
+	private val defaultSkjemanr = "NAV 55-00.60"
+	private val defaultTema = "BID"
+	private val defaultTittel = "Avtale om barnebidrag"
 
 	@BeforeEach
 	fun setup() {
@@ -96,7 +99,7 @@ class SoknadServiceTest {
 		val soknadService = lagSoknadService()
 
 		val brukerid = testpersonid
-		val skjemanr = "NAV 95-00.11"
+		val skjemanr = defaultSkjemanr
 		val spraak = "nb_NO"
 		val dokumentSoknadDto = soknadService.opprettSoknad(brukerid, skjemanr, spraak)
 
@@ -111,14 +114,15 @@ class SoknadServiceTest {
 		val soknadService = lagSoknadService()
 
 		val brukerid = testpersonid
-		val skjemanr = "NAV 14-05.07"
+		val skjemanr = defaultSkjemanr
+		val skjemaTittel_en = "Agreement regarding child support"
 		val spraak = "fr"
 		val dokumentSoknadDto = soknadService.opprettSoknad(brukerid, skjemanr, spraak)
 
 		assertEquals(brukerid, dokumentSoknadDto.brukerId)
 		assertEquals(skjemanr, dokumentSoknadDto.skjemanr)
 		assertEquals(spraak, dokumentSoknadDto.spraak) // Beholder ønsket språk
-		assertEquals("Application for lump-sum grant at birth", dokumentSoknadDto.tittel) // engelsk backup for fransk
+		assertEquals(skjemaTittel_en, dokumentSoknadDto.tittel) // engelsk backup for fransk
 		assertNotNull(dokumentSoknadDto.innsendingsId)
 	}
 
@@ -557,7 +561,7 @@ class SoknadServiceTest {
 	}
 
 	private fun testOgSjekkOpprettingAvSoknad(soknadService: SoknadService, vedleggsListe: List<String> = listOf(), brukerid: String = testpersonid, spraak: String = "nb_NO"): DokumentSoknadDto {
-		val skjemanr = "NAV 95-00.11"
+		val skjemanr = defaultSkjemanr
 		val dokumentSoknadDto = soknadService.opprettSoknad(brukerid, skjemanr, spraak, vedleggsListe)
 
 		assertEquals(brukerid, dokumentSoknadDto.brukerId)
@@ -752,7 +756,7 @@ class SoknadServiceTest {
 		val soknadService = lagSoknadService()
 
 		val brukerid = testpersonid
-		val skjemanr = "NAV 95-00.11"
+		val skjemanr = defaultSkjemanr
 		val spraak = "nb_NO"
 
 		val dokumentSoknadDtoList = mutableListOf<DokumentSoknadDto>()
@@ -772,7 +776,7 @@ class SoknadServiceTest {
 		val soknadService = lagSoknadService()
 
 		val brukerid = testpersonid
-		val skjemanr = "NAV 95-00.11"
+		val skjemanr = defaultSkjemanr
 		val spraak = "nb_NO"
 
 		val dokumentSoknadDtoList = mutableListOf<DokumentSoknadDto>()

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/service/SoknadServiceTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/service/SoknadServiceTest.kt
@@ -256,7 +256,7 @@ class SoknadServiceTest {
 		val arkiverteVedlegg: List<InnsendtVedleggDto> = listOf(InnsendtVedleggDto(vedleggsnr = "NAV 08-09.10", tittel = "Søknad om å beholde sykepenger under opphold i utlandet"))
 
 		val arkivertSoknad = AktivSakDto("NAV 08-07.04D", "Søknad om Sykepenger",  "SYK",
-			LocalDateTime.now().minusDays(10L).atOffset(ZoneOffset.UTC), ettersending = false, innsendingsId = UUID.randomUUID().toString(), innsendtVedleggDtos = arkiverteVedlegg )
+			mapTilOffsetDateTime(LocalDateTime.now(), -10L), ettersending = false, innsendingsId = UUID.randomUUID().toString(), innsendtVedleggDtos = arkiverteVedlegg )
 
 		val ettersending = soknadService.opprettSoknadForEttersendingAvVedleggGittArkivertSoknad(brukerId = "1234", arkivertSoknad = arkivertSoknad, "no_NO", listOf("W1") )
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.5</version>
+		<version>2.7.8</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
@@ -21,10 +21,10 @@
 	<properties>
 		<java.version>17</java.version>
 		<kotlin.version>1.7.20</kotlin.version>
-		<spring-boot.version>2.7.5</spring-boot.version>
+		<spring-boot.version>2.7.8</spring-boot.version>
 		<openapi-generator-maven-plugin.version>6.2.0</openapi-generator-maven-plugin.version>
 		<okhttp3.version>4.10.0</okhttp3.version>
-		<io-netty.version>4.1.84.Final</io-netty.version>
+		<io-netty.version>4.1.86.Final</io-netty.version>
 		<okio.version>3.2.0</okio.version>
 		<jackson.version>2.13.4</jackson.version>
 	</properties>


### PR DESCRIPTION
Følgende endringer er gjort:

- Fikset feil som gjorde at en midlertidig opplastet fil ble sendt inn selv om søker har endret status til sendes senere eller sendes av andre.
- Skjemanummer brukt i en del tester er endret da denne ikke lenger er tilgjengelig fra Sanity.
- Fikset feil på konvertering fra localdatetime til datetimeoffset
- Oppdatert versjoner på dependencies.