### PR TITLE
Arkiveringsstatus via kafka

### DIFF
--- a/.nais/nais-gcp.yml
+++ b/.nais/nais-gcp.yml
@@ -82,12 +82,12 @@ spec:
 
   gcp:
     sqlInstances:
-      - type: POSTGRES_14
+      - diskAutoresize: true
+        diskSize: {{ default_database_size }}
+        type: POSTGRES_14
         databases:
           - name: {{ database-name }}
             envVarPrefix: DATABASE
-            diskAutoresize: false
-            diskSize: 30
 
   envFrom:
     - secret: shared-innsending-secret

--- a/.nais/nais-gcp.yml
+++ b/.nais/nais-gcp.yml
@@ -25,7 +25,7 @@ spec:
     enabled: true
     path: /internal/prometheus
   replicas:
-    min: 4
+    min: 2
     max: 6
   resources:
     limits:

--- a/.nais/nais-gcp.yml
+++ b/.nais/nais-gcp.yml
@@ -37,6 +37,7 @@ spec:
   leaderElection: true
   kafka:
     pool: {{kafka-pool}}
+    streams: true
 
   tokenx:
     enabled: true

--- a/.nais/nais-gcp.yml
+++ b/.nais/nais-gcp.yml
@@ -35,6 +35,8 @@ spec:
       cpu: 200m
       memory: 1Gi
   leaderElection: true
+  kafka:
+    pool: {{kafka-pool}}
 
   tokenx:
     enabled: true

--- a/.nais/preprod-gcp.json
+++ b/.nais/preprod-gcp.json
@@ -42,7 +42,7 @@
 		"SOKNADSFILLAGER_SCOPE": "api://dev-gcp.team-soknad.soknadsfillager/.default",
 		"SOKNADSMOTTAKER_SCOPE": "api://dev-gcp.team-soknad.soknadsmottaker/.default",
 		"SAF_SCOPE": "api://dev-fss.teamdokumenthandtering.saf-q1/.default",
-		"KAFKA_SECURITY": "true",
+		"KAFKA_SECURITY": "TRUE",
 		"KAFKA_MESSAGE_TOPIC": "team-soknad.privat-soknadinnsending-messages-v2-dev"
 	}
 

--- a/.nais/preprod-gcp.json
+++ b/.nais/preprod-gcp.json
@@ -12,6 +12,7 @@
 		"soknadsmottaker",
 		"soknadsfillager"
 	],
+	"kafka-pool": "nav-dev",
 	"env": {
 		"DATABASE_NAME": "dokumentinnsending-dev",
 		"SPRING_PROFILES_ACTIVE": "dev",
@@ -40,6 +41,9 @@
 		"AZURE_TENANT": "trygdeetaten.no",
 		"SOKNADSFILLAGER_SCOPE": "api://dev-gcp.team-soknad.soknadsfillager/.default",
 		"SOKNADSMOTTAKER_SCOPE": "api://dev-gcp.team-soknad.soknadsmottaker/.default",
-		"SAF_SCOPE": "api://dev-fss.teamdokumenthandtering.saf-q1/.default"
+		"SAF_SCOPE": "api://dev-fss.teamdokumenthandtering.saf-q1/.default",
+		"KAFKA_SECURITY": "true",
+		"KAFKA_MESSAGE_TOPIC": "team-soknad.privat-soknadinnsending-messages-v2-dev"
 	}
+
 }

--- a/.nais/preprod-gcp.json
+++ b/.nais/preprod-gcp.json
@@ -3,6 +3,7 @@
 	"namespace": "team-soknad",
 	"team": "team-soknad",
 	"database-name": "dokumentinnsending-dev",
+	"default_database_size": 10,
 	"ingresses": [
 		"https://www.dev.nav.no/innsending-api-gcp",
 		"https://innsending-api-gcp.dev.nav.no"

--- a/.nais/prod-gcp.json
+++ b/.nais/prod-gcp.json
@@ -12,6 +12,7 @@
 		"soknadsmottaker",
 		"soknadsfillager"
 	],
+	"kafka-pool": "nav-prod",
 	"env": {
 		"DATABASE_NAME": "dokumentinnsending",
 		"SPRING_PROFILES_ACTIVE": "prod",
@@ -40,6 +41,8 @@
 		"AZURE_TENANT": "nav.no",
 		"SOKNADSFILLAGER_SCOPE": "api://prod-gcp.team-soknad.soknadsfillager/.default",
 		"SOKNADSMOTTAKER_SCOPE": "api://prod-gcp.team-soknad.soknadsmottaker/.default",
-		"SAF_SCOPE": "api://prod-fss.teamdokumenthandtering.saf/.default"
+		"SAF_SCOPE": "api://prod-fss.teamdokumenthandtering.saf/.default",
+		"KAFKA_SECURITY": "true",
+		"KAFKA_MESSAGE_TOPIC": "team-soknad.privat-soknadinnsending-messages-v2"
 	}
 }

--- a/.nais/prod-gcp.json
+++ b/.nais/prod-gcp.json
@@ -3,6 +3,7 @@
 	"namespace": "team-soknad",
 	"team": "team-soknad",
 	"database-name": "dokumentinnsending",
+	"default_database_size": 20,
 	"ingresses": [
 		"https://www.nav.no/innsending-api-gcp",
 		"https://innsending-api-gcp.nav.no"

--- a/api/src/main/resources/innsending-api.yml
+++ b/api/src/main/resources/innsending-api.yml
@@ -671,6 +671,12 @@ components:
           items:
             $ref: "#/components/schemas/InnsendtVedleggDto"
 
+    ArkiveringsStatusDto:
+      type: string
+      enum: ["IkkeSatt", "Arkivert", "ArkiveringFeilet"]
+      description: Status for om innsendt søknad er blitt arkivert. Ikke innsendte søknader skal ha arkiveringsStatus IkkeSatt.
+      example:
+
     Beskrivelse:
       type: string
       description: Utdypende forklaring til et vedlegg.
@@ -774,6 +780,8 @@ components:
           example: 2021-12-03T15:10:00Z
         fristForEttersendelse:
           $ref: "#/components/schemas/FristForEttersendelse"
+        arkiveringsStatus:
+          $ref: "#/components/schemas/ArkiveringsStatusDto"
 
 
     FilDto:

--- a/api/src/main/resources/innsending-api.yml
+++ b/api/src/main/resources/innsending-api.yml
@@ -675,7 +675,7 @@ components:
       type: string
       enum: ["IkkeSatt", "Arkivert", "ArkiveringFeilet"]
       description: Status for om innsendt søknad er blitt arkivert. Ikke innsendte søknader skal ha arkiveringsStatus IkkeSatt.
-      example:
+      example: Arkivert
 
     Beskrivelse:
       type: string

--- a/innsender/pom.xml
+++ b/innsender/pom.xml
@@ -77,6 +77,11 @@
 			<artifactId>okhttp</artifactId>
 			<version>${okhttp3.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka-clients</artifactId>
+			<version>${kafka.version}</version>
+		</dependency>
 
 		<dependency>
 			<groupId>io.github.resilience4j</groupId>

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/config/KafkaConfig.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/config/KafkaConfig.kt
@@ -1,0 +1,27 @@
+package no.nav.soknad.innsending.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "kafka")
+data class KafkaConfig (
+	val applicationId: String,
+	val brokers: String,
+	val security: SecurityConfig,
+	val topics: Topics,
+)
+
+data class SecurityConfig(
+	val enabled  : String,
+	val protocol : String,
+	val keyStoreType : String,
+	val keyStorePath : String,
+	val keyStorePassword : String,
+	val trustStorePath : String,
+	val trustStorePassword : String
+)
+
+data class Topics(
+	val messageTopic : String,
+)

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/consumerapis/kafka/KafkaMessageReader.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/consumerapis/kafka/KafkaMessageReader.kt
@@ -1,0 +1,66 @@
+package no.nav.soknad.innsending.consumerapis.kafka
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import no.nav.soknad.innsending.config.KafkaConfig
+import no.nav.soknad.innsending.repository.SoknadRepository
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Service
+import java.time.Duration
+import java.util.*
+import javax.annotation.PostConstruct
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.toJavaDuration
+
+@Service
+@Profile("prod | dev")
+class KafkaMessageReader(
+	private val kafkaConfig: KafkaConfig,
+	private val soknadRepository: SoknadRepository) {
+
+	private val logger = LoggerFactory.getLogger(javaClass)
+
+	@PostConstruct
+	fun startKafka() {
+		val job = GlobalScope.launch {
+			readMessages()
+		}
+		logger.info("Startet polling av ${kafkaConfig.topics} med job ${job.key}")
+	}
+
+	private fun readMessages() {
+		val topic = kafkaConfig.topics.messageTopic
+		val groupId = kafkaConfig.applicationId
+
+		val props = Properties().apply {
+			put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaConfig.brokers)
+			put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java)
+			put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java)
+			put(ConsumerConfig.GROUP_ID_CONFIG, groupId)
+			put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+		}
+		KafkaConsumer<String, String>(props).use { it ->
+			it.subscribe(listOf(topic))
+			while (true) {
+				val messages = it.poll(Duration.ofMillis(5000))
+				for (message in messages) {
+					val key = message.key()
+					if (message.value().startsWith("**Archiving: OK")) {
+						soknadRepository.updateErArkivert(true, listOf(key))
+					} else if (message.value().startsWith("**Archiving: FAILED")) {
+						soknadRepository.updateErArkivert(false, listOf(key))
+					}
+				}
+				it.commitSync()
+			}
+		}
+	}
+
+}

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/consumerapis/kafka/KafkaMessageReader.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/consumerapis/kafka/KafkaMessageReader.kt
@@ -61,8 +61,7 @@ class KafkaMessageReader(
 					}
 				}
 				it.commitSync()
-				innsenderMetrics.archivingFailedSet(soknadRepository.countArkiveringFeilet())
-				logger.debug("**Ferdig behandlet mottatte meldinger")
+				logger.debug("**Ferdig behandlet mottatte meldinger.")
 			}
 		}
 	}

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/consumerapis/saf/SafClient.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/consumerapis/saf/SafClient.kt
@@ -30,6 +30,8 @@ class SafClient(
 	 * Denne funksjonen er ment for bruk kun internt i innsending-api
 	 * pga. at tjenesten har ikke tilgangsstyring på brukernivå.
 	 * Dataene som hentes skal altså ikke sendes ut til bruker.
+	 * MERK at denne fuksjonen pt. ikke er i bruk da vi ikke kunne basere oss på oppslag mot arkivet med innsendt søknad sin brukerId,
+	 * da det er tilfeller der saksbehandler endrer i arkivet id til innsender. Vi beholder koden i tilfelle vi i framtiden trenger den.
 	 */
 	override fun hentDokumentoversiktBruker(brukerId: String): List<ArkiverteSaker> {
 		return runBlocking {

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/consumerapis/saf/SafClient.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/consumerapis/saf/SafClient.kt
@@ -67,7 +67,7 @@ class SafClient(
 	}
 
 	fun formatDate(date: LocalDateTime): String {
-		val formatter = DateTimeFormatter.ofPattern("YYYY-MM-DD")
+		val formatter = DateTimeFormatter.ofPattern("YYYY-MM-dd")
 		return date.format(formatter)
 	}
 

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/consumerapis/saf/SafClient.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/consumerapis/saf/SafClient.kt
@@ -53,7 +53,7 @@ class SafClient(
 			HentDokumentoversiktBruker(
 				HentDokumentoversiktBruker.Variables(
 					BrukerIdInput(id = brukerId, type = BrukerIdType.FNR),
-					10, listOf(Journalposttype.I), listOf(), format(LocalDateTime.now().minusDays(2))
+					10, listOf(Journalposttype.I), listOf(), formatDate(LocalDateTime.now().minusDays(2))
 				)
 			)
 		)
@@ -65,6 +65,12 @@ class SafClient(
 		}
 		throw RuntimeException("Oppslag mot saf feilet, ingen data returnert.")
 	}
+
+	fun formatDate(date: LocalDateTime): String {
+		val formatter = DateTimeFormatter.ofPattern("YYYY-MM-DD")
+		return date.format(formatter)
+	}
+
 
 	fun format(date: LocalDateTime): String {
 		val formatter = DateTimeFormatter.ofPattern("YYYY-MM-DD'T'hh:mm:ss")

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/consumerapis/saf/SafClient.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/consumerapis/saf/SafClient.kt
@@ -7,11 +7,17 @@ import no.nav.soknad.innsending.consumerapis.saf.dto.ArkiverteSaker
 import no.nav.soknad.innsending.exceptions.BackendErrorException
 import no.nav.soknad.innsending.saf.generated.HentDokumentoversiktBruker
 import no.nav.soknad.innsending.saf.generated.enums.BrukerIdType
+import no.nav.soknad.innsending.saf.generated.enums.Journalposttype
 import no.nav.soknad.innsending.saf.generated.hentdokumentoversiktbruker.Dokumentoversikt
 import no.nav.soknad.innsending.saf.generated.inputs.BrukerIdInput
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.*
+
 
 @Component
 @Profile("test | dev | prod")
@@ -47,7 +53,7 @@ class SafClient(
 			HentDokumentoversiktBruker(
 				HentDokumentoversiktBruker.Variables(
 					BrukerIdInput(id = brukerId, type = BrukerIdType.FNR),
-					10
+					10, listOf(Journalposttype.I), listOf(), format(LocalDateTime.now().minusDays(2))
 				)
 			)
 		)
@@ -58,6 +64,11 @@ class SafClient(
 			return response.data!!.dokumentoversiktBruker
 		}
 		throw RuntimeException("Oppslag mot saf feilet, ingen data returnert.")
+	}
+
+	fun format(date: LocalDateTime): String {
+		val formatter = DateTimeFormatter.ofPattern("YYYY-MM-DD'T'hh:mm:ss")
+		return date.format(formatter)
 	}
 
 }

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/repository/ArkiveringsStatus.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/repository/ArkiveringsStatus.kt
@@ -1,0 +1,7 @@
+package no.nav.soknad.innsending.repository
+
+enum class ArkiveringsStatus {
+	IkkeSatt,
+	Arkivert,
+	ArkiveringFeilet
+}

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/repository/ArkiveringsStatusAttributeConverter.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/repository/ArkiveringsStatusAttributeConverter.kt
@@ -1,0 +1,15 @@
+package no.nav.soknad.innsending.repository
+
+import javax.persistence.AttributeConverter
+import javax.persistence.Converter
+
+@Converter(autoApply = true)
+class ArkiveringsStatusAttributeConverter: AttributeConverter<ArkiveringsStatus, String?> {
+	override fun convertToDatabaseColumn(arkiveringsstatus: ArkiveringsStatus): String {
+		return if (arkiveringsstatus == null) ArkiveringsStatus.IkkeSatt.name else arkiveringsstatus.name
+	}
+
+	override fun convertToEntityAttribute(arkiveringsstatus: String?): ArkiveringsStatus {
+		return if (arkiveringsstatus == null) ArkiveringsStatus.IkkeSatt else ArkiveringsStatus.valueOf(arkiveringsstatus)
+	}
+}

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/repository/SoknadDbData.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/repository/SoknadDbData.kt
@@ -25,5 +25,5 @@ data class SoknadDbData(
 	@Column(name = "kanlasteoppannet", columnDefinition = "boolean") val kanlasteoppannet: Boolean? = true,
 	@Column(name = "forsteinnsendingsdato", columnDefinition = "TIMESTAMP WITH TIME ZONE") val forsteinnsendingsdato: LocalDateTime?,
 	@Column(name = "ettersendingsfrist", columnDefinition = "int") val ettersendingsfrist: Long? = Constants.DEFAULT_FRIST_FOR_ETTERSENDELSE,
-	@Column(name = "erarkivert", columnDefinition = "boolean") val erarkivert: Boolean? = null,
+	@Column(name = "arkiveringsstatus", columnDefinition = "varchar") val arkiveringsstatus: ArkiveringsStatus
 )

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/repository/SoknadRepository.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/repository/SoknadRepository.kt
@@ -47,6 +47,10 @@ interface SoknadRepository : JpaRepository<SoknadDbData, Long> {
 	@Query(value = "UPDATE SoknadDbData SET erarkivert = :erArkivert WHERE innsendingsid in (:innsendingsids)", nativeQuery = false)
 	fun updateErArkivert(erArkivert: Boolean, @Param("innsendingsids") innsendingsids: List<String>)
 
-	@Query(value = "SELECT COUNT(*) FROM soknad WHERE erarkivert = :erarkivert", nativeQuery = true)
-	fun countErarkivertIs(@Param("erarkivert") erarkivert: Boolean): Long
+	@Query(value = "SELECT COUNT(*) FROM soknad WHERE erarkivert = true", nativeQuery = true)
+	fun countErArkivert(): Long
+
+	@Query(value = "SELECT COUNT(*) FROM soknad WHERE erarkivert is null or erarkivert = false", nativeQuery = true)
+	fun countIkkeArkivert(): Long
+
 }

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/repository/SoknadRepository.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/repository/SoknadRepository.kt
@@ -56,7 +56,7 @@ interface SoknadRepository : JpaRepository<SoknadDbData, Long> {
 	@Query(value = "SELECT COUNT(*) FROM soknad WHERE arkiveringsstatus = 'IkkeSatt' AND status  = 'Innsendt' AND innsendtdato < :before", nativeQuery = true)
 	fun countInnsendtIkkeBehandlet(@Param("before") before: LocalDateTime): Long
 
-	@Query(value = "SELECT innsendingid FROM soknad WHERE arkiveringsstatus = 'IkkeSatt' AND status  = 'Innsendt' AND innsendtdato < :before", nativeQuery = true)
+	@Query(value = "SELECT innsendingsid FROM soknad WHERE arkiveringsstatus = 'IkkeSatt' AND status  = 'Innsendt' AND innsendtdato < :before", nativeQuery = true)
 	fun findInnsendtAndArkiveringsStatusIkkeSatt(@Param("before") before: LocalDateTime): List<String>
 
 }

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/repository/SoknadRepository.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/repository/SoknadRepository.kt
@@ -39,18 +39,24 @@ interface SoknadRepository : JpaRepository<SoknadDbData, Long> {
 	@Query(value = "SELECT * FROM soknad WHERE opprettetdato <= :opprettetFor ORDER BY opprettetdato", nativeQuery = true)
 	fun findAllByOpprettetdatoBefore(@Param("opprettetFor") opprettetFor: OffsetDateTime): List<SoknadDbData>
 
-	@Query(value = "SELECT * FROM soknad WHERE erarkivert IS NOT TRUE AND innsendtdato >= :start AND innsendtdato <= :end ORDER BY innsendtdato", nativeQuery = true)
+	@Query(value = "SELECT * FROM soknad WHERE arkiveringsstatus <> 'Arkivert' AND innsendtdato >= :start AND innsendtdato <= :end ORDER BY innsendtdato", nativeQuery = true)
 	fun findAllNotArchivedAndInnsendtdatoBetween(@Param("start") start: LocalDateTime, @Param("end") end: LocalDateTime): List<SoknadDbData>
 
 	@Transactional
 	@Modifying
-	@Query(value = "UPDATE SoknadDbData SET erarkivert = :erArkivert WHERE innsendingsid in (:innsendingsids)", nativeQuery = false)
-	fun updateErArkivert(erArkivert: Boolean, @Param("innsendingsids") innsendingsids: List<String>)
+	@Query(value = "UPDATE SoknadDbData SET arkiveringsstatus = :arkiveringsStatus WHERE innsendingsid in (:innsendingsids)", nativeQuery = false)
+	fun updateArkiveringsStatus(arkiveringsStatus: ArkiveringsStatus, @Param("innsendingsids") innsendingsids: List<String>)
 
-	@Query(value = "SELECT COUNT(*) FROM soknad WHERE erarkivert = true", nativeQuery = true)
+	@Query(value = "SELECT COUNT(*) FROM soknad WHERE arkiveringsstatus = 'Arkivert' AND status = 'Innsendt'", nativeQuery = true)
 	fun countErArkivert(): Long
 
-	@Query(value = "SELECT COUNT(*) FROM soknad WHERE erarkivert is null or erarkivert = false", nativeQuery = true)
-	fun countIkkeArkivert(): Long
+	@Query(value = "SELECT COUNT(*) FROM soknad WHERE arkiveringsstatus = 'ArkiveringFeilet' AND status  = 'Innsendt'", nativeQuery = true)
+	fun countArkiveringFeilet(): Long
+
+	@Query(value = "SELECT COUNT(*) FROM soknad WHERE arkiveringsstatus = 'IkkeSatt' AND status  = 'Innsendt' AND innsendtdato < before", nativeQuery = true)
+	fun countInnsendtIkkeBehandlet(@Param("before") before: LocalDateTime): Long
+
+	@Query(value = "SELECT innsendingid FROM soknad WHERE arkiveringsstatus = 'IkkeSatt' AND status  = 'Innsendt' AND innsendtdato < before", nativeQuery = true)
+	fun findInnsendtAndArkiveringsStatusIkkeSatt(@Param("before") before: LocalDateTime): List<String>
 
 }

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/repository/SoknadRepository.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/repository/SoknadRepository.kt
@@ -53,10 +53,10 @@ interface SoknadRepository : JpaRepository<SoknadDbData, Long> {
 	@Query(value = "SELECT COUNT(*) FROM soknad WHERE arkiveringsstatus = 'ArkiveringFeilet' AND status  = 'Innsendt'", nativeQuery = true)
 	fun countArkiveringFeilet(): Long
 
-	@Query(value = "SELECT COUNT(*) FROM soknad WHERE arkiveringsstatus = 'IkkeSatt' AND status  = 'Innsendt' AND innsendtdato < before", nativeQuery = true)
+	@Query(value = "SELECT COUNT(*) FROM soknad WHERE arkiveringsstatus = 'IkkeSatt' AND status  = 'Innsendt' AND innsendtdato < :before", nativeQuery = true)
 	fun countInnsendtIkkeBehandlet(@Param("before") before: LocalDateTime): Long
 
-	@Query(value = "SELECT innsendingid FROM soknad WHERE arkiveringsstatus = 'IkkeSatt' AND status  = 'Innsendt' AND innsendtdato < before", nativeQuery = true)
+	@Query(value = "SELECT innsendingid FROM soknad WHERE arkiveringsstatus = 'IkkeSatt' AND status  = 'Innsendt' AND innsendtdato < :before", nativeQuery = true)
 	fun findInnsendtAndArkiveringsStatusIkkeSatt(@Param("before") before: LocalDateTime): List<String>
 
 }

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/SkjemaDokumentSoknadTransformer.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/SkjemaDokumentSoknadTransformer.kt
@@ -18,7 +18,8 @@ class SkjemaDokumentSoknadTransformer {
 		vedleggsListe = lagVedleggsListe(input), id = null, innsendingsId = null, ettersendingsId = null, spraak = finnSpraakFraInput(input.spraak),
 		innsendtDato = null, visningsSteg = 0, visningsType = VisningsType.fyllUt,
 		kanLasteOppAnnet = input.kanLasteOppAnnet ?: input.vedleggsListe?.any { it.propertyNavn != null && it.propertyNavn == "annenDokumentasjon"},
-			forsteInnsendingsDato = null, fristForEttersendelse = input.fristForEttersendelse ?: Constants.DEFAULT_FRIST_FOR_ETTERSENDELSE )
+		forsteInnsendingsDato = null, fristForEttersendelse = input.fristForEttersendelse ?: Constants.DEFAULT_FRIST_FOR_ETTERSENDELSE,
+		arkiveringsStatus = ArkiveringsStatusDto.ikkeSatt)
 
 //	kanLasteOppAnnet = input.vedleggsListe?.any { it.property == "annenDokumentasjon" : it.vedleggsnr == "N6" && it.label == "Annen dokumentasjon" })
 

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/service/MappingUtils.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/service/MappingUtils.kt
@@ -64,7 +64,8 @@ fun lagDokumentSoknadDto(soknadDbData: SoknadDbData, vedleggDbDataListe: List<Ve
 		kanLasteOppAnnet = soknadDbData.kanlasteoppannet ?: true,
 		innsendingsFristDato = beregnInnsendingsFrist(soknadDbData),
 		forsteInnsendingsDato = mapTilOffsetDateTime(soknadDbData.forsteinnsendingsdato),
-		fristForEttersendelse = soknadDbData.ettersendingsfrist?: Constants.DEFAULT_FRIST_FOR_ETTERSENDELSE
+		fristForEttersendelse = soknadDbData.ettersendingsfrist?: Constants.DEFAULT_FRIST_FOR_ETTERSENDELSE,
+		arkiveringsStatus = mapTilArkiveringsStatusDto(soknadDbData.arkiveringsstatus )
 	)
 
 private fun beregnInnsendingsFrist(soknadDbData: SoknadDbData): OffsetDateTime {
@@ -124,8 +125,23 @@ fun mapTilSoknadDb(dokumentSoknadDto: DokumentSoknadDto, innsendingsId: String, 
 		opprettetdato = mapTilLocalDateTime(dokumentSoknadDto.opprettetDato)!!, endretdato = LocalDateTime.now(),
 		innsendtdato = if (status == SoknadsStatus.Innsendt) LocalDateTime.now()	else mapTilLocalDateTime(dokumentSoknadDto.innsendtDato),
 		visningssteg = dokumentSoknadDto.visningsSteg, visningstype = dokumentSoknadDto.visningsType, kanlasteoppannet = dokumentSoknadDto.kanLasteOppAnnet ?: true,
-		forsteinnsendingsdato = mapTilLocalDateTime(dokumentSoknadDto.forsteInnsendingsDato), ettersendingsfrist = dokumentSoknadDto.fristForEttersendelse
+		forsteinnsendingsdato = mapTilLocalDateTime(dokumentSoknadDto.forsteInnsendingsDato), ettersendingsfrist = dokumentSoknadDto.fristForEttersendelse,
+		arkiveringsstatus = mapTilDbArkiveringsStatus(dokumentSoknadDto.arkiveringsStatus ?: ArkiveringsStatusDto.ikkeSatt)
 	)
+
+private fun mapTilArkiveringsStatusDto(arkiveringsStatus: ArkiveringsStatus): ArkiveringsStatusDto =
+	when (arkiveringsStatus) {
+		ArkiveringsStatus.IkkeSatt -> ArkiveringsStatusDto.ikkeSatt
+		ArkiveringsStatus.Arkivert ->  ArkiveringsStatusDto.arkivert
+		ArkiveringsStatus.ArkiveringFeilet  -> ArkiveringsStatusDto.arkiveringFeilet
+	}
+
+private fun mapTilDbArkiveringsStatus(arkiveringsStatusDto: ArkiveringsStatusDto): ArkiveringsStatus =
+	when (arkiveringsStatusDto) {
+		ArkiveringsStatusDto.ikkeSatt -> ArkiveringsStatus.IkkeSatt
+		ArkiveringsStatusDto.arkivert ->  ArkiveringsStatus.Arkivert
+		ArkiveringsStatusDto.arkiveringFeilet  -> ArkiveringsStatus.ArkiveringFeilet
+	}
 
 fun mapTilSoknadsStatus(soknadsStatus: SoknadsStatusDto?, newStatus: SoknadsStatus? ): SoknadsStatus {
 	return newStatus ?:

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/service/ScheduledOperationsService.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/service/ScheduledOperationsService.kt
@@ -25,6 +25,8 @@ class ScheduledOperationsService(
 		}
 
 		innsenderMetrics.absentInArchive(soknaderAbsentInArchive)
+		innsenderMetrics.archivingFailedSet(soknadRepository.countArkiveringFeilet())
+
 	}
 
 }

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/service/ScheduledOperationsService.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/service/ScheduledOperationsService.kt
@@ -14,7 +14,7 @@ class ScheduledOperationsService(
 
 	private val logger = LoggerFactory.getLogger(javaClass)
 
-	fun checkIfApplicationsAreArchived(timespanHours: Long, offsetHours: Long) {
+	fun checkIfApplicationsAreArchived(offsetHours: Long) {
 		val soknaderAbsentInArchive = soknadRepository.countInnsendtIkkeBehandlet(LocalDateTime.now().minusHours(offsetHours))
 		if (soknaderAbsentInArchive > 0) {
 			logger.error("Total number of applications not yet processed for archiving by soknadsarkiverer: $soknaderAbsentInArchive")

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/service/ScheduledOperationsService.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/service/ScheduledOperationsService.kt
@@ -28,7 +28,7 @@ class ScheduledOperationsService(
 			logger.error("Detected ${absentInJoark.size} submitted application(s) [$start -> $end] which do not exist in Joark: $innsendingsIdList")
 		}
 
-		val soknaderAbsentInArchive = soknadRepository.countErarkivertIs(false)
+		val soknaderAbsentInArchive = soknadRepository.countIkkeArkivert()
 		logger.info("Total number of applications absent in archive: $soknaderAbsentInArchive")
 		innsenderMetrics.absentInArchive(soknaderAbsentInArchive)
 	}

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/service/ScheduledOperationsService.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/service/ScheduledOperationsService.kt
@@ -30,6 +30,7 @@ class ScheduledOperationsService(
 			.fold(emptyPair) { acc, pair -> Pair(acc.first + pair.first, acc.second + pair.second) }
 
 		if (existsInJoark.isNotEmpty()) {
+			logger.debug("Antall arkivert ${existsInJoark.size}")
 			soknadRepository.updateErArkivert(true, existsInJoark.map { soknad -> soknad.innsendingsid })
 		}
 

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/service/ScheduledOperationsService.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/service/ScheduledOperationsService.kt
@@ -1,6 +1,5 @@
 package no.nav.soknad.innsending.service
 
-import no.nav.soknad.innsending.repository.SoknadDbData
 import no.nav.soknad.innsending.repository.SoknadRepository
 import no.nav.soknad.innsending.supervision.InnsenderMetrics
 import org.slf4j.LoggerFactory
@@ -10,46 +9,28 @@ import java.time.LocalDateTime
 @Service
 class ScheduledOperationsService(
 	private val soknadRepository: SoknadRepository,
-	private val safService: SafService,
 	private val innsenderMetrics: InnsenderMetrics
 ) {
 
 	private val logger = LoggerFactory.getLogger(javaClass)
 
-	fun updateSoknadErArkivert(timespanHours: Long, offsetHours: Long) {
+	fun checkIfApplicationsAreArchived(timespanHours: Long, offsetHours: Long) {
 		val now = LocalDateTime.now()
 		val start = now.minusHours(timespanHours + offsetHours)
 		val end = now.minusHours(offsetHours)
 		logger.info("Verifying that applications submitted between [$start -> $end] exist in Joark...")
 
-		val emptyPair = Pair(emptyList<SoknadDbData>(), emptyList<SoknadDbData>())
-		val (existsInJoark, absentInJoark) = soknadRepository
+		val absentInJoark = soknadRepository
 			.findAllNotArchivedAndInnsendtdatoBetween(start, end)
-			.groupBy { soknad -> soknad.brukerid }
-			.map { entry -> existsInJoark(entry.key, entry.value) }
-			.fold(emptyPair) { acc, pair -> Pair(acc.first + pair.first, acc.second + pair.second) }
-
-		if (existsInJoark.isNotEmpty()) {
-			logger.debug("Antall arkivert ${existsInJoark.size}")
-			soknadRepository.updateErArkivert(true, existsInJoark.map { soknad -> soknad.innsendingsid })
-		}
 
 		if (absentInJoark.isNotEmpty()) {
 			val innsendingsIdList = absentInJoark.map { soknad -> soknad.innsendingsid }
-			soknadRepository.updateErArkivert(false, innsendingsIdList)
 			logger.error("Detected ${absentInJoark.size} submitted application(s) [$start -> $end] which do not exist in Joark: $innsendingsIdList")
 		}
-
-		logger.info("Done verifying applications submitted between [$start -> $end]")
 
 		val soknaderAbsentInArchive = soknadRepository.countErarkivertIs(false)
 		logger.info("Total number of applications absent in archive: $soknaderAbsentInArchive")
 		innsenderMetrics.absentInArchive(soknaderAbsentInArchive)
-	}
-
-	private fun existsInJoark(brukerid: String, soknader: List<SoknadDbData>): Pair<List<SoknadDbData>, List<SoknadDbData>> {
-		val arkiverteSoknader = safService.hentArkiverteSaker(brukerid)
-		return soknader.partition { soknad -> arkiverteSoknader.any { sak -> sak.eksternReferanseId == soknad.innsendingsid } }
 	}
 
 }

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/service/SoknadService.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/service/SoknadService.kt
@@ -62,7 +62,8 @@ class SoknadService(
 					null, Utilities.laginnsendingsId(), kodeverkSkjema.tittel ?: "", kodeverkSkjema.skjemanummer ?: "",
 					kodeverkSkjema.tema ?: "", spraak, SoknadsStatus.Opprettet, brukerId, null, LocalDateTime.now(),
 					LocalDateTime.now(), null, 0, VisningsType.dokumentinnsending, true,
-						forsteinnsendingsdato = null, ettersendingsfrist = Constants.DEFAULT_FRIST_FOR_ETTERSENDELSE
+					forsteinnsendingsdato = null, ettersendingsfrist = Constants.DEFAULT_FRIST_FOR_ETTERSENDELSE,
+					arkiveringsstatus = ArkiveringsStatus.IkkeSatt
 				)
 			)
 
@@ -319,7 +320,8 @@ class SoknadService(
 				visningssteg = 0,
 				visningstype = VisningsType.ettersending,
 				forsteinnsendingsdato = mapTilLocalDateTime(forsteInnsendingsDato),
-				ettersendingsfrist = fristForEttersendelse
+				ettersendingsfrist = fristForEttersendelse,
+				arkiveringsstatus = ArkiveringsStatus.IkkeSatt
 			)
 		)
 	}
@@ -411,7 +413,8 @@ class SoknadService(
 					VisningsType.ettersending,
 					true,
 					mapTilLocalDateTime(arkivertSoknad.innsendtDato),
-					Constants.DEFAULT_FRIST_FOR_ETTERSENDELSE
+					Constants.DEFAULT_FRIST_FOR_ETTERSENDELSE,
+					arkiveringsstatus = ArkiveringsStatus.IkkeSatt
 				)
 			)
 

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/service/SoknadService.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/service/SoknadService.kt
@@ -947,12 +947,20 @@ class SoknadService(
 			fillagerAPI.lagreFiler(soknadDto.innsendingsId!!, opplastedeVedlegg + kvitteringForArkivering)
 		} catch (e: Exception) {
 			reportException(e, operation, soknadDto.tema)
-			logger.error("Feil ved sending av filer for søknad ${soknadDto.innsendingsId} til NAV, ${e.message}")
+			logger.error("Feil ved sending av filer for søknad ${soknadDto.innsendingsId} ti       l NAV, ${e.message}")
 			throw BackendErrorException(e.message, "Feil ved sending av filer for søknad ${soknadDto.innsendingsId} til NAV", "errorCode.backendError.sendToNAVError")
 		}
 
 		// send soknadmetada til soknadsmottaker
 		try {
+			val soknadDb = repo.hentSoknadDb(soknadDto.id!!)
+			if (soknadDb.get().status == SoknadsStatus.Innsendt) {
+				logger.warn("${soknadDto.innsendingsId}: Søknad allerede innsendt, avbryter")
+				throw IllegalActionException(
+					"Søknaden er allerede sendt inn",
+					"Søknaden er innsendt og kan ikke sendes på nytt.",
+					"errorCode.illegalAction.applicationSentInOrDeleted")
+			}
 			soknadsmottakerAPI.sendInnSoknad(soknadDto, opplastedeVedlegg + kvitteringForArkivering)
 		} catch (e: Exception) {
 			reportException(e, operation, soknadDto.tema)
@@ -1050,9 +1058,17 @@ class SoknadService(
 					mapTilSoknadsStatus(soknadDto.status, null)),
 					KodeverkSkjema(tittel = soknadDto.tittel, skjemanummer = soknadDto.skjemanr, beskrivelse = soknadDto.tittel, tema = soknadDto.tema ) ), null)
 
-		val oppdatertSoknadDto = hentSoknad(soknadDto.id!!)
-		lagreFil(oppdatertSoknadDto, FilDto(hovedDokumentDto.id!!, null, hovedDokumentDto.vedleggsnr!!, Mimetype.applicationSlashPdf,
-			dummySkjema.size, dummySkjema, OffsetDateTime.now() ))
+		val hovedDokFil = repo.hentFilerTilVedlegg(soknadDto.innsendingsId!!, hovedDokumentDto.id!!)
+		if (hovedDokFil.isNotEmpty() && hovedDokFil.first().data != null) {
+			return hentSoknad(soknadDto.id!!)
+		}
+		val oppdatertSoknad = hentSoknad(soknadDto.id!!)
+		lagreFil(
+			oppdatertSoknad, FilDto(
+					hovedDokumentDto.id!!, null, hovedDokumentDto.vedleggsnr!!, Mimetype.applicationSlashPdf,
+					dummySkjema.size, dummySkjema, OffsetDateTime.now()
+				)
+			)
 
 		return hentSoknad(soknadDto.innsendingsId!!)
 	}

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/supervision/InnsenderMetrics.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/supervision/InnsenderMetrics.kt
@@ -29,7 +29,7 @@ class InnsenderMetrics(private val registry: CollectorRegistry) {
 	private val absentInArchiveName = "applications_absent_in_archive_total"
 	private val absentInArchiveHelp = "Number of sent in applications that not yet have been archived"
 	private val archivingFailedName = "archiving_of_applications_failed_total"
-	private val archivingFailedHelp = "Number of applications for which where archiving failed"
+	private val archivingFailedHelp = "Number of applications for which archiving failed"
 
 	private val operationsCounter = registerCounter(name, help, operationLabel)
 	private val operationsErrorCounter = registerCounter(errorName, helpError, operationLabel)

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/supervision/InnsenderMetrics.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/supervision/InnsenderMetrics.kt
@@ -27,13 +27,16 @@ class InnsenderMetrics(private val registry: CollectorRegistry) {
 	private val databaseSizeName = "database_size"
 	private val databaseSizeHelp = "Database size"
 	private val absentInArchiveName = "applications_absent_in_archive_total"
-	private val absentInArchiveHelp = "Number of applications absent in archive"
+	private val absentInArchiveHelp = "Number of sent in applications that not yet have been archived"
+	private val archivingFailedName = "archiving_of_applications_failed_total"
+	private val archivingFailedHelp = "Number of applications for which where archiving failed"
 
 	private val operationsCounter = registerCounter(name, help, operationLabel)
 	private val operationsErrorCounter = registerCounter(errorName, helpError, operationLabel)
 	private val operationLatencyHistogram = registerLatencyHistogram(latency, latencyHelp, operationLabel)
 	private val databaseGauge = registerGauge(databaseSizeName, databaseSizeHelp)
 	private val absentInArchiveGauge = registerGauge(absentInArchiveName, absentInArchiveHelp)
+	private val archivingFailedGauge = registerGauge(archivingFailedName, archivingFailedHelp)
 
 	private val jobLastSuccessGauge = Gauge
 		.build()
@@ -87,6 +90,8 @@ class InnsenderMetrics(private val registry: CollectorRegistry) {
 	fun databaseSizeGet() = databaseGauge.get()
 
 	fun absentInArchive(number: Long) = absentInArchiveGauge.set(number.toDouble())
+
+	fun archivingFailedSet(number: Long) = archivingFailedGauge.set(number.toDouble())
 
 	fun updateJobLastSuccess(jobName: String) = jobLastSuccessGauge.labels(jobName).setToCurrentTime()
 }

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/supervision/VerifyArchivedApplications.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/supervision/VerifyArchivedApplications.kt
@@ -28,7 +28,7 @@ class VerifyArchivedApplications(
 	fun run() {
 		try {
 			if (leaderSelectionUtility.isLeader()) {
-				scheduledOperationsService.updateSoknadErArkivert(timespanHours, offsetHours)
+				scheduledOperationsService.checkIfApplicationsAreArchived(timespanHours, offsetHours)
 				metrics.updateJobLastSuccess(JOB_NAME)
 			}
 		} catch (e: Exception) {

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/supervision/VerifyArchivedApplications.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/supervision/VerifyArchivedApplications.kt
@@ -14,21 +14,20 @@ class VerifyArchivedApplications(
 	private val leaderSelectionUtility: LeaderSelectionUtility,
 	private val scheduledOperationsService: ScheduledOperationsService,
 	private val metrics: InnsenderMetrics,
-	@Value("\${verifyArchivedApplications.offsetHours}") private val offsetHours: Long,
-	@Value("\${verifyArchivedApplications.timespanHours}") private val timespanHours: Long,
+	@Value("\${verifyArchivedApplications.offsetHours}") private val offsetHours: Long
 ) {
 
 	private val logger = LoggerFactory.getLogger(javaClass)
 
 	init {
-		logger.info("Initializing scheduled job ${javaClass.kotlin.simpleName} (offsetHours=$offsetHours, timespanHours=${timespanHours})")
+		logger.info("Initializing scheduled job ${javaClass.kotlin.simpleName} (offsetHours=$offsetHours)")
 	}
 
 	@Scheduled(cron = "\${cron.runVerifyArchivedApplications}")
 	fun run() {
 		try {
 			if (leaderSelectionUtility.isLeader()) {
-				scheduledOperationsService.checkIfApplicationsAreArchived(timespanHours, offsetHours)
+				scheduledOperationsService.checkIfApplicationsAreArchived(offsetHours)
 				metrics.updateJobLastSuccess(JOB_NAME)
 			}
 		} catch (e: Exception) {

--- a/innsender/src/main/resources/application.yml
+++ b/innsender/src/main/resources/application.yml
@@ -136,10 +136,10 @@ spring:
     hikari:
       minimum-idle: 1
       maximum-pool-size: 20
-      connection-timeout: 30000
+      connection-timeout: 50000
       max-lifetime: 50001
-      validationTimeout: 5000
-      leak-detection-threshold: 50000
+      validationTimeout: 20000
+      leak-detection-threshold: 40000
     dbcp2:
       test-on-borrow: true
       validation-query: "SELECT 1"

--- a/innsender/src/main/resources/application.yml
+++ b/innsender/src/main/resources/application.yml
@@ -32,7 +32,7 @@ verifyArchivedApplications:
 
 
 kafka:
-  applicationId: ${AZURE_APP_CLIENT_ID}
+  applicationId: ${KAFKA_STREAMS_APPLICATION_ID}
   brokers: ${KAFKA_BROKERS}
   security:
     enabled: ${KAFKA_SECURITY}

--- a/innsender/src/main/resources/application.yml
+++ b/innsender/src/main/resources/application.yml
@@ -29,6 +29,22 @@ ettersendingsfrist: 14
 verifyArchivedApplications:
   offsetHours: 2
   timespanHours: 24
+
+
+kafka:
+  applicationId: ${APPLICATION_ID}
+  brokers: ${KAFKA_BROKERS}
+  security:
+    enabled: ${KAFKA_SECURITY}
+    protocol: SSL
+    keyStoreType: PKCS12
+    keyStorePath: ${KAFKA_KEYSTORE_PATH}
+    keyStorePassword: ${KAFKA_CREDSTORE_PASSWORD}
+    trustStorePath: ${KAFKA_TRUSTSTORE_PATH}
+    trustStorePassword: ${KAFKA_CREDSTORE_PASSWORD}
+  topics:
+    messageTopic: ${KAFKA_MESSAGE_TOPIC}
+
 ---
 spring:
   config:
@@ -168,6 +184,7 @@ restconfig:
   safselvbetjeningUrl: ${SAFSELVBETJENING_URL}
   safUrl: ${SAF_URL}
   azureUrl: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+
 
 
 brukernotifikasjonconfig:

--- a/innsender/src/main/resources/application.yml
+++ b/innsender/src/main/resources/application.yml
@@ -32,7 +32,7 @@ verifyArchivedApplications:
 
 
 kafka:
-  applicationId: ${APPLICATION_ID}
+  applicationId: ${AZURE_APP_CLIENT_ID}
   brokers: ${KAFKA_BROKERS}
   security:
     enabled: ${KAFKA_SECURITY}

--- a/innsender/src/main/resources/application.yml
+++ b/innsender/src/main/resources/application.yml
@@ -22,7 +22,7 @@ cron:
   slettInnsendtFilEldreEnn: 21
   startSlettPermanentIkkeInnsendteSoknader: 0 0 3 * * *
   slettPermanentEldreEnn: 365
-  runVerifyArchivedApplications: 0 0 * * * *
+  runVerifyArchivedApplications: 0 0,11 0 ? * *
 
 ettersendingsfrist: 14
 

--- a/innsender/src/main/resources/application.yml
+++ b/innsender/src/main/resources/application.yml
@@ -22,14 +22,13 @@ cron:
   slettInnsendtFilEldreEnn: 21
   startSlettPermanentIkkeInnsendteSoknader: 0 0 3 * * *
   slettPermanentEldreEnn: 365
+  # Kjører hvert 11. minutt
   runVerifyArchivedApplications: 0 0,11 0 ? * *
 
 ettersendingsfrist: 14
 
 verifyArchivedApplications:
   offsetHours: 2
-  timespanHours: 24
-
 
 kafka:
   applicationId: ${KAFKA_STREAMS_APPLICATION_ID}
@@ -129,6 +128,7 @@ spring:
       on-profile: dev
 
 cron:
+  # Kjører hvert 11. minutt
   runVerifyArchivedApplications: 0 */11 * ? * *
 
 verifyArchivedApplications:

--- a/innsender/src/main/resources/application.yml
+++ b/innsender/src/main/resources/application.yml
@@ -129,7 +129,7 @@ spring:
       on-profile: dev
 
 cron:
-  runVerifyArchivedApplications: 0 */15 * ? * *
+  runVerifyArchivedApplications: 0 0 0 1 JAN ?
 
 verifyArchivedApplications:
   offsetHours: 1

--- a/innsender/src/main/resources/application.yml
+++ b/innsender/src/main/resources/application.yml
@@ -129,7 +129,7 @@ spring:
       on-profile: dev
 
 cron:
-  runVerifyArchivedApplications: 0 */15 * ? * *
+  runVerifyArchivedApplications: 0 */11 * ? * *
 
 verifyArchivedApplications:
   offsetHours: 1

--- a/innsender/src/main/resources/application.yml
+++ b/innsender/src/main/resources/application.yml
@@ -129,7 +129,7 @@ spring:
       on-profile: dev
 
 cron:
-  runVerifyArchivedApplications: 0 0 0 1 JAN ?
+  runVerifyArchivedApplications: 0 */15 * ? * *
 
 verifyArchivedApplications:
   offsetHours: 1

--- a/innsender/src/main/resources/db/migration/V1.18__add_arkiveringsstatus.sql
+++ b/innsender/src/main/resources/db/migration/V1.18__add_arkiveringsstatus.sql
@@ -1,5 +1,8 @@
+DROP index IF EXISTS soknad_arkiveringsstatus_idx;
+ALTER TABLE soknad DROP COLUMN IF EXISTS arkiveringsstatus;
+
 ALTER TABLE soknad ADD COLUMN arkiveringsstatus varchar NOT NULL default 'IkkeSatt';
 
-UPDATE soknad SET arkiveringsstatus='arkivert' WHERE status = 'Innsendt';
+UPDATE soknad SET arkiveringsstatus='Arkivert' WHERE status = 'Innsendt';
 
 CREATE INDEX soknad_arkiveringsstatus_idx ON soknad(arkiveringsstatus);

--- a/innsender/src/main/resources/db/migration/V1.18__add_arkiveringsstatus.sql
+++ b/innsender/src/main/resources/db/migration/V1.18__add_arkiveringsstatus.sql
@@ -1,0 +1,5 @@
+ALTER TABLE soknad ADD COLUMN arkiveringsstatus varchar NOT NULL default 'IkkeSatt';
+
+UPDATE soknad SET arkiveringsstatus='arkivert' WHERE status = 'Innsendt';
+
+CREATE INDEX soknad_arkiveringsstatus_idx ON soknad(arkiveringsstatus);

--- a/innsender/src/main/resources/db/migration/V1.19__drop_erarkivert.sql
+++ b/innsender/src/main/resources/db/migration/V1.19__drop_erarkivert.sql
@@ -1,0 +1,3 @@
+DROP INDEX soknad_erarkivert_idx;
+ALTER TABLE soknad DROP COLUMN erarkivert;
+

--- a/innsender/src/main/resources/graphql/saf/hentDokumentoversiktBruker.graphql
+++ b/innsender/src/main/resources/graphql/saf/hentDokumentoversiktBruker.graphql
@@ -1,5 +1,5 @@
-query ($brukerId: BrukerIdInput!, $foerste: Int!) {
-	dokumentoversiktBruker(brukerId: $brukerId, foerste: $foerste) {
+query ($brukerId: BrukerIdInput!, $foerste: Int!, $journalposttyper: [Journalposttype]!, $journalstatuser: [Journalstatus]!, $fraDato: Date!) {
+	dokumentoversiktBruker(brukerId: $brukerId, foerste: $foerste, journalposttyper: $journalposttyper, journalstatuser: $journalstatuser, fraDato: $fraDato) {
 		journalposter {
 			journalpostId
 			eksternReferanseId

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/cleanup/FjernGamleSoknaderTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/cleanup/FjernGamleSoknaderTest.kt
@@ -12,9 +12,6 @@ import no.nav.soknad.innsending.consumerapis.soknadsfillager.FillagerInterface
 import no.nav.soknad.innsending.consumerapis.soknadsmottaker.MottakerInterface
 import no.nav.soknad.innsending.model.DokumentSoknadDto
 import no.nav.soknad.innsending.model.SoknadsStatusDto
-import no.nav.soknad.innsending.repository.FilRepository
-import no.nav.soknad.innsending.repository.SoknadRepository
-import no.nav.soknad.innsending.repository.VedleggRepository
 import no.nav.soknad.innsending.service.RepositoryUtils
 import no.nav.soknad.innsending.service.SoknadService
 import no.nav.soknad.innsending.supervision.InnsenderMetrics

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/rest/SkjemaRestApiTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/rest/SkjemaRestApiTest.kt
@@ -18,7 +18,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock
-import org.springframework.core.ParameterizedTypeReference
 import org.springframework.core.io.ClassPathResource
 import org.springframework.http.*
 import org.springframework.test.context.ActiveProfiles

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/service/ScheduledOperationsServiceTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/service/ScheduledOperationsServiceTest.kt
@@ -3,7 +3,9 @@ package no.nav.soknad.innsending.service
 import io.mockk.*
 import io.mockk.impl.annotations.InjectMockKs
 import no.nav.soknad.innsending.repository.ArkiveringsStatus
+import no.nav.soknad.innsending.repository.FilRepository
 import no.nav.soknad.innsending.repository.SoknadRepository
+import no.nav.soknad.innsending.repository.VedleggRepository
 import no.nav.soknad.innsending.supervision.InnsenderMetrics
 import no.nav.soknad.innsending.utils.SoknadDbDataTestdataBuilder
 import org.junit.jupiter.api.AfterEach
@@ -28,6 +30,12 @@ class ScheduledOperationsServiceTest {
 	@Autowired
 	private lateinit var soknadRepository: SoknadRepository
 
+	@Autowired
+	private lateinit var vedleggRepository: VedleggRepository
+
+	@Autowired
+	private lateinit var filRepository: FilRepository
+
 	@InjectMockKs
 	private val innsenderMetrics = mockk<InnsenderMetrics>()
 
@@ -38,6 +46,8 @@ class ScheduledOperationsServiceTest {
 
 	@AfterEach
 	fun cleanup() {
+		filRepository.deleteAll()
+		vedleggRepository.deleteAll()
 		soknadRepository.deleteAll()
 	}
 

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/service/ScheduledOperationsServiceTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/service/ScheduledOperationsServiceTest.kt
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
-import org.junit.Ignore
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -21,7 +20,6 @@ import java.time.LocalDateTime
 private const val TIMESPAN_HOURS = 24L
 private const val OFFSET_HOURS = 2L
 
-@Ignore
 @SpringBootTest
 @ActiveProfiles("spring")
 @EnableTransactionManagement

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/service/ScheduledOperationsServiceTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/service/ScheduledOperationsServiceTest.kt
@@ -23,7 +23,6 @@ private const val OFFSET_HOURS = 2L
 @SpringBootTest
 @ActiveProfiles("spring")
 @EnableTransactionManagement
-@Disabled
 class ScheduledOperationsServiceTest {
 
 	@Autowired

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/service/ScheduledOperationsServiceTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/service/ScheduledOperationsServiceTest.kt
@@ -4,11 +4,11 @@ import io.mockk.*
 import io.mockk.impl.annotations.InjectMockKs
 import no.nav.soknad.innsending.repository.SoknadRepository
 import no.nav.soknad.innsending.supervision.InnsenderMetrics
-import no.nav.soknad.innsending.utils.ArkivertSakerTestdataBuilder
 import no.nav.soknad.innsending.utils.SoknadDbDataTestdataBuilder
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -45,6 +45,7 @@ class ScheduledOperationsServiceTest {
 	)
 
 	@Test
+	@Disabled
 	fun testAtSoknadSomIkkeEksistererIArkivetBlirMarkertSomIkkeArkivert() {
 		val innsendtdato = LocalDateTime.now().minusHours(OFFSET_HOURS + 1)
 		val soknad = SoknadDbDataTestdataBuilder(innsendtdato = innsendtdato).build()
@@ -61,6 +62,7 @@ class ScheduledOperationsServiceTest {
 	}
 
 	@Test
+	@Disabled
 	fun testAtSoknadSomEksistererIArkivetBlirMarkertSomArkivert() {
 		val innsendtdato = LocalDateTime.now().minusHours(OFFSET_HOURS + 1)
 		val soknad = SoknadDbDataTestdataBuilder(innsendtdato = innsendtdato).build()
@@ -79,6 +81,7 @@ class ScheduledOperationsServiceTest {
 
 
 	@Test
+	@Disabled
 	fun testAtSoknadAIkkeMarkeresSomArkivertOgSoknadBMarkeresSomArkivert() {
 		val innsendtdatoA = LocalDateTime.now().minusHours(OFFSET_HOURS + 1)
 		val soknadA = SoknadDbDataTestdataBuilder(innsendtdato = innsendtdatoA).build()
@@ -96,6 +99,7 @@ class ScheduledOperationsServiceTest {
 	}
 
 	@Test
+	@Disabled
 	fun testAtSoknadSomForstMarkeresSomIkkeArkivertMarkeresSomArkivertVedNesteSjekk() {
 		val innsendtdato = LocalDateTime.now().minusHours(OFFSET_HOURS + 1)
 		val soknad = SoknadDbDataTestdataBuilder(innsendtdato = innsendtdato).build()
@@ -123,6 +127,7 @@ class ScheduledOperationsServiceTest {
 
 
 	@Test
+	@Disabled
 	fun testAtSoknadInnsendtIForkantAvTimespanOgMarkertSomIkkeArkivertTellesMedVedRegistreringAvMetrics() {
 		val innsendtdato = LocalDateTime.now().minusHours(TIMESPAN_HOURS + OFFSET_HOURS + 2)
 		val soknad = SoknadDbDataTestdataBuilder(innsendtdato = innsendtdato, erarkivert = false).build()

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/service/ScheduledOperationsServiceTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/service/ScheduledOperationsServiceTest.kt
@@ -56,7 +56,7 @@ class ScheduledOperationsServiceTest {
 		every { safService.hentArkiverteSaker(soknad.brukerid) } returns emptyList()
 
 		val service = lagScheduledOperationsService()
-		service.updateSoknadErArkivert(TIMESPAN_HOURS, OFFSET_HOURS)
+		service.checkIfApplicationsAreArchived(TIMESPAN_HOURS, OFFSET_HOURS)
 
 		val lagretSoknad = soknadRepository.findById(soknad.id!!)
 		assertTrue(lagretSoknad.isPresent)
@@ -75,7 +75,7 @@ class ScheduledOperationsServiceTest {
 		every { safService.hentArkiverteSaker(soknad.brukerid) } returns listOf(sak)
 
 		val service = lagScheduledOperationsService()
-		service.updateSoknadErArkivert(TIMESPAN_HOURS, OFFSET_HOURS)
+		service.checkIfApplicationsAreArchived(TIMESPAN_HOURS, OFFSET_HOURS)
 
 		val lagretSoknad = soknadRepository.findById(soknad.id!!)
 		assertTrue(lagretSoknad.isPresent)
@@ -94,7 +94,7 @@ class ScheduledOperationsServiceTest {
 		every { safService.hentArkiverteSaker(soknad.brukerid) } returns listOf(sak)
 
 		val service = lagScheduledOperationsService()
-		service.updateSoknadErArkivert(TIMESPAN_HOURS, OFFSET_HOURS)
+		service.checkIfApplicationsAreArchived(TIMESPAN_HOURS, OFFSET_HOURS)
 
 		verify { safService wasNot called }
 
@@ -119,7 +119,7 @@ class ScheduledOperationsServiceTest {
 		every { safService.hentArkiverteSaker(soknadA.brukerid) } returns listOf(sakB)
 
 		val service = lagScheduledOperationsService()
-		service.updateSoknadErArkivert(TIMESPAN_HOURS, OFFSET_HOURS)
+		service.checkIfApplicationsAreArchived(TIMESPAN_HOURS, OFFSET_HOURS)
 
 		val lagretSoknadA = soknadRepository.findById(soknadA.id!!)
 		assertTrue(lagretSoknadA.isPresent)
@@ -144,12 +144,12 @@ class ScheduledOperationsServiceTest {
 
 		val service = lagScheduledOperationsService()
 
-		service.updateSoknadErArkivert(TIMESPAN_HOURS, OFFSET_HOURS)
+		service.checkIfApplicationsAreArchived(TIMESPAN_HOURS, OFFSET_HOURS)
 		val lagretSoknad1 = soknadRepository.findById(soknad.id!!)
 		assertTrue(lagretSoknad1.isPresent)
 		assertEquals(false, lagretSoknad1.get().erarkivert)
 
-		service.updateSoknadErArkivert(TIMESPAN_HOURS, OFFSET_HOURS)
+		service.checkIfApplicationsAreArchived(TIMESPAN_HOURS, OFFSET_HOURS)
 		val lagretSoknad2 = soknadRepository.findById(soknad.id!!)
 		assertTrue(lagretSoknad2.isPresent)
 		assertEquals(true, lagretSoknad2.get().erarkivert)
@@ -171,7 +171,7 @@ class ScheduledOperationsServiceTest {
 		var exceptionThrown = false;
 		val service = lagScheduledOperationsService()
 		try {
-			service.updateSoknadErArkivert(TIMESPAN_HOURS, OFFSET_HOURS)
+			service.checkIfApplicationsAreArchived(TIMESPAN_HOURS, OFFSET_HOURS)
 		} catch (e: Exception) {
 			exceptionThrown = true
 		}
@@ -194,7 +194,7 @@ class ScheduledOperationsServiceTest {
 		every { safService.hentArkiverteSaker(soknad.brukerid) } returns listOf(sak)
 
 		val service = lagScheduledOperationsService()
-		service.updateSoknadErArkivert(TIMESPAN_HOURS, OFFSET_HOURS)
+		service.checkIfApplicationsAreArchived(TIMESPAN_HOURS, OFFSET_HOURS)
 
 		verify { safService wasNot called }
 
@@ -215,7 +215,7 @@ class ScheduledOperationsServiceTest {
 		every { safService.hentArkiverteSaker(soknad.brukerid) } returns listOf(sak)
 
 		val service = lagScheduledOperationsService()
-		service.updateSoknadErArkivert(TIMESPAN_HOURS, OFFSET_HOURS)
+		service.checkIfApplicationsAreArchived(TIMESPAN_HOURS, OFFSET_HOURS)
 
 		verify { safService wasNot called }
 

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/service/SoknadServiceTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/service/SoknadServiceTest.kt
@@ -118,7 +118,7 @@ class SoknadServiceTest {
 
 		val brukerid = testpersonid
 		val skjemanr = defaultSkjemanr
-		val skjemaTittel_en = "Agreement regarding child support"
+		val skjemaTittel_en = skjemaService.hentSkjemaEllerVedlegg(defaultSkjemanr, "en").tittel
 		val spraak = "fr"
 		val dokumentSoknadDto = soknadService.opprettSoknad(brukerid, skjemanr, spraak)
 

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/utils/SoknadDbDataTestdataBuilder.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/utils/SoknadDbDataTestdataBuilder.kt
@@ -1,6 +1,7 @@
 package no.nav.soknad.innsending.utils
 
 import no.nav.soknad.innsending.model.VisningsType
+import no.nav.soknad.innsending.repository.ArkiveringsStatus
 import no.nav.soknad.innsending.repository.SoknadDbData
 import no.nav.soknad.innsending.repository.SoknadsStatus
 import java.time.LocalDateTime
@@ -13,13 +14,15 @@ data class SoknadDbDataTestdataBuilder(
 	var tema: String = "BID",
 	var innsendtdato: LocalDateTime? = null,
 	var innsendingsId: String = UUID.randomUUID().toString(),
-	var erarkivert: Boolean? = null
+	var arkiveringsStatus: ArkiveringsStatus? = ArkiveringsStatus.IkkeSatt
 ) {
 	fun brukerId(brukerId: String) = apply { this.brukerId = brukerId }
 	fun skjemanr(skjemanr: String) = apply { this.skjemanr = skjemanr }
 	fun tittel(skjematittel: String) = apply { this.tittel = skjematittel }
 	fun tema(tema: String) = apply { this.tema = tema }
 	fun innsendtdato(innsendtdato: LocalDateTime?) = apply { this.innsendtdato = innsendtdato }
-	fun erarkivert(erarkivert: Boolean?) = apply { this.erarkivert = erarkivert }
-	fun build() = SoknadDbData(null, innsendingsId, tittel, skjemanr, tema, "nb", SoknadsStatus.Innsendt, brukerId, null, LocalDateTime.now(), LocalDateTime.now(), innsendtdato, 0, VisningsType.fyllUt, true, null, 14, this.erarkivert)
+	fun erarkivert(arkiveringsStatus: ArkiveringsStatus) = apply { this.arkiveringsStatus = arkiveringsStatus }
+	fun build() = SoknadDbData(null, innsendingsId, tittel, skjemanr, tema, "nb", SoknadsStatus.Innsendt, brukerId,
+		null, LocalDateTime.now(), LocalDateTime.now(), innsendtdato, 0, VisningsType.fyllUt, true,
+		null, 14, this.arkiveringsStatus ?: ArkiveringsStatus.IkkeSatt)
 }

--- a/innsender/src/test/resources/application-test.yml
+++ b/innsender/src/test/resources/application-test.yml
@@ -25,6 +25,20 @@ management:
   prometheus:
   enabled: true
 
+kafka:
+  applicationId: testApplicationId
+  brokers: localhost:29092
+  security:
+    enabled: FALSE
+    protocol: SSL
+    keyStoreType: PKCS12
+    keyStorePath: dummy
+    keyStorePassword: dummy
+    trustStorePath: dummy
+    trustStorePassword: dummy
+  topics:
+    messageTopic: privat-soknadinnsending-messages-v2-dev
+
 restconfig:
   version: 1.0
   username: srvuser

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
 		<io-netty.version>4.1.86.Final</io-netty.version>
 		<okio.version>3.2.0</okio.version>
 		<jackson.version>2.13.4</jackson.version>
+		<kafka.version>3.4.0</kafka.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
Endret logikken for å kontrollere at innsendte søknader er blitt arkivert.
1. Lagt til kode for å lytte på kafka topic for å sjekke om søknad er blitt arkivert eller arkivering er feilet. Oppdaterer ny property, arkiveringsstatus, på soknad tabellen iht. responsen.
2. Lagt til skedulert oppgave som sjekker at alle søknader innsendt for mer enn x-timer siden er blitt behandlet av soknadsarkiverer (dvs. sjekker og gir feil dersom det er noen insendte soknader med arkiveringsstatus= IkkeSatt)