### PR TITLE
Fiks bug med for stor PDF etter utflating

### DIFF
--- a/innsender/src/main/kotlin/no/nav/soknad/pdfutilities/KonverterTilPdf.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/pdfutilities/KonverterTilPdf.kt
@@ -59,7 +59,8 @@ class KonverterTilPdf {
 
 	fun flatUtPdf(fil: ByteArray): ByteArray {
 		val antallSider = AntallSider().finnAntallSider(fil)
-
+		logger.info("Antall sider i PDF: {}", antallSider)
+		
 		// Konvertere fra PDF til bilde og tilbake til PDF
 		// Max størrelse på vedlegg er 50mb og for å ikke overskride dette så konverterer vi ikke PDF'er på over 50 sider
 		// (PDF'en blir veldig mye større med png av hver side)

--- a/innsender/src/main/kotlin/no/nav/soknad/pdfutilities/KonverterTilPdf.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/pdfutilities/KonverterTilPdf.kt
@@ -58,8 +58,12 @@ class KonverterTilPdf {
 	}
 
 	fun flatUtPdf(fil: ByteArray): ByteArray {
+		val antallSider = AntallSider().finnAntallSider(fil)
+
 		// Konvertere fra PDF til bilde og tilbake til PDF
-		if (harSkrivbareFelt(fil)) {
+		// Max størrelse på vedlegg er 50mb og for å ikke overskride dette så konverterer vi ikke PDF'er på over 50 sider
+		// (PDF'en blir veldig mye større med png av hver side)
+		if (harSkrivbareFelt(fil) && antallSider <= 50) {
 			val images = KonverterTilPng().konverterTilPng(fil)
 			val pdfList = mutableListOf<ByteArray>()
 			for (element in images) pdfList.add(createPDFFromImage(element))
@@ -75,7 +79,7 @@ class KonverterTilPdf {
 				val scaledSize = getScaledDimension(pdImage.width, pdImage.height)
 				val page = PDPage(PDRectangle(scaledSize.width.toFloat(), scaledSize.height.toFloat()))
 				doc.addPage(page)
-				PDPageContentStream(doc, page, AppendMode.APPEND, false, true).use { contentStream ->
+				PDPageContentStream(doc, page, AppendMode.APPEND, true, true).use { contentStream ->
 					contentStream.drawImage(
 						pdImage,
 						0f,

--- a/innsender/src/main/kotlin/no/nav/soknad/pdfutilities/KonverterTilPng.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/pdfutilities/KonverterTilPng.kt
@@ -57,7 +57,7 @@ class KonverterTilPng {
 					var bim =
 						pdfRenderer.renderImageWithDPI(pageIndex, 100f, ImageType.RGB)
 					bim = scaleImage(bim, Dimension(827, 1169), true)
-					ImageIOUtil.writeImage(bim, "PNG", baos, 100, 1.0F)
+					ImageIOUtil.writeImage(bim, "PNG", baos, 100, 0.9F)
 					bim.flush()
 					return baos.toByteArray()
 				}

--- a/innsender/src/main/kotlin/no/nav/soknad/pdfutilities/Validerer.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/pdfutilities/Validerer.kt
@@ -107,7 +107,7 @@ class Validerer {
 		try {
 			file = File.createTempFile(fileName, ".pdf")
 			document = Loader.loadPDF(bytes)
-			document.save(fileName, CompressParameters.NO_COMPRESSION)
+			document.save(file, CompressParameters.NO_COMPRESSION)
 			result = PreflightParser.validate(file)
 			logger.info("PDF/A resultat: ${result.isValid}")
 

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/rest/FrontEndRestApiTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/rest/FrontEndRestApiTest.kt
@@ -254,12 +254,12 @@ class FrontEndRestApiTest : ApplicationTest() {
 		assertEquals(OpplastingsStatusDto.ikkeValgt, vedleggN6.opplastingsStatus)
 
 		val multipart = LinkedMultiValueMap<Any, Any>()
-		multipart.add("file", ClassPathResource("/NAV 54-editert.pdf"))
+		multipart.add("file", ClassPathResource("/pdfs/acroform-fields-tom-array.pdf"))
 
 		val postFilRequestN6 = HttpEntity(multipart, Hjelpemetoder.createHeaders(token, MediaType.MULTIPART_FORM_DATA))
 
 		assertThrows(Exception::class.java) {
-			for (i in 1..100) {
+			for (i in 1..50) {
 				val postFilResponseN6 = restTemplate.exchange(
 					"http://localhost:${serverPort}/frontend/v1/soknad/${soknadDto.innsendingsId!!}/vedlegg/${vedleggN6.id}/fil",
 					HttpMethod.POST,

--- a/innsender/src/test/kotlin/no/nav/soknad/pdfutilities/KonverterTilPdfTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/pdfutilities/KonverterTilPdfTest.kt
@@ -28,6 +28,20 @@ class KonverterTilPdfTest {
 	}
 
 	@Test
+	fun `Skal ikke flate ut PDF'er på over 50 sider`() {
+		val skrivbarPdf = Hjelpemetoder.getBytesFromFile("/pdfs/acroform-fields-tom-array.pdf")
+		assertTrue(KonverterTilPdf().harSkrivbareFelt(skrivbarPdf))
+
+		val flatetPdf = KonverterTilPdf().flatUtPdf(skrivbarPdf)
+		assertTrue(KonverterTilPdf().harSkrivbareFelt(flatetPdf)) // Skal fortsatt ha skrivbare felt
+
+		val antallSider = AntallSider().finnAntallSider(skrivbarPdf)
+		assertEquals(antallSider, AntallSider().finnAntallSider(flatetPdf))
+
+		assertEquals(skrivbarPdf, flatetPdf)
+	}
+
+	@Test
 	fun verifiserKonverteringAvJpg() {
 		val jpg = Hjelpemetoder.getBytesFromFile("/2MbJpg.jpg")
 


### PR DESCRIPTION
Endrer compressionQuality og legger til sjekk på antall sider for utflating for å sikre at vi ikke går over 50mb grensen for vedlegg