### PR TITLE
Add new endpoints for ettersending

### DIFF
--- a/.nais/nais-gcp.yml
+++ b/.nais/nais-gcp.yml
@@ -72,6 +72,9 @@ spec:
           cluster: dev-gcp
         - application: statuspoll
           namespace: navdig
+        - application: sykepengesoknad-backend
+          namespace: flex
+
     outbound:
       external:
       {{#each outboundExternalHosts}}

--- a/api/src/main/resources/innsending-api.yml
+++ b/api/src/main/resources/innsending-api.yml
@@ -826,6 +826,20 @@ paths:
                 application/json:
                   schema:
                     $ref: "#/components/schemas/RestErrorResponseDto"
+                  example:
+                    message: Autentisering feilet
+                    timestamp: 2023-12-21T09:31:40.549032434
+                    errorCode: errorCode.unauthorized
+            500:
+              description: Feil i backend
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/RestErrorResponseDto"
+                  example:
+                    message: Noe gikk galt, prøv igjen senere
+                    timestamp: 2023-12-21T09:31:40.549032434
+                    errorCode: somethingFailedTryLater
           tags:
             - ekstern
 
@@ -1116,8 +1130,7 @@ components:
 
     BrukernotifikasjonsType:
       type: string
-      enum: [ "utkast", "oppgave" ]
-      description: "Hvilke type brukernotifikasjon som skal sendes. Default: utkast"
+      enum: [utkast, oppgave]
       example: oppgave
 
     Document:
@@ -1234,6 +1247,9 @@ components:
           description: Liste av vedlegg som kan lastes opp
           items:
             $ref: "#/components/schemas/InnsendtVedleggDto"
+          example:
+            - vedleggsnr: W1
+              tittel: "Dokumentasjon på mottatt bidrag"
 
     FilDto:
       type: object
@@ -1550,11 +1566,13 @@ components:
         timestamp:
           type: string
           format: date-time
-          description: Tidspunkt i UTC
-          example: 2021-12-03T14:10:00Z
         errorCode:
           type: string
           description: Feilkode
+      example:
+        message: Noe gikk galt, prøv igjen senere
+        timestamp: 2023-12-21T09:31:40.549032434
+        errorCode: somethingFailedTryLater
 
     Saksinformasjon:
       type: object

--- a/api/src/main/resources/innsending-api.yml
+++ b/api/src/main/resources/innsending-api.yml
@@ -226,6 +226,27 @@ paths:
                   $ref: "#/components/schemas/PrefillData"
         tags:
           - fyllut
+  /fyllut/v1/ettersending:
+        post:
+          summary: Kall for å opprette en ettersending
+          operationId: opprettEttersending
+
+          requestBody:
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/OpprettEttersending"
+            required: true
+
+          responses:
+            201:
+              description: Opprettet ettersending
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/DokumentSoknadDto"
+          tags:
+            - ettersending
 
   /innsendte/v1/files/{uuids}:
     get:
@@ -315,27 +336,6 @@ paths:
       tags:
         - soknadsveiviser
 
-  /frontend/v1/ettersending:
-      post:
-        summary: Kall for å opprette en ettersending
-        operationId: opprettEttersending
-
-        requestBody:
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/OpprettEttersending"
-          required: true
-
-        responses:
-          201:
-            description: Opprettet ettersending
-            content:
-              application/json:
-                schema:
-                  $ref: "#/components/schemas/DokumentSoknadDto"
-        tags:
-          - ettersending
 
   /frontend/v1/soknad/{innsendingsId}:
     get:

--- a/api/src/main/resources/innsending-api.yml
+++ b/api/src/main/resources/innsending-api.yml
@@ -313,6 +313,28 @@ paths:
       tags:
         - soknadsveiviser
 
+  /frontend/v1/ettersending:
+      post:
+        summary: Kall for å opprette en ettersending
+        operationId: opprettEttersending
+
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpprettEttersending"
+          required: true
+
+        responses:
+          201:
+            description: Created
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/DokumentSoknadDto"
+        tags:
+          - ettersending
+
   /frontend/v1/soknad/{innsendingsId}:
     get:
       summary: Kall for å hente opprettet søknad gitt innsendingsId.

--- a/api/src/main/resources/innsending-api.yml
+++ b/api/src/main/resources/innsending-api.yml
@@ -4,8 +4,8 @@ info:
   version: 1.0.1
   title: Innsending-api
   contact:
-    name: team-soknad
-    email: team-soknad@nav.no
+    name: team-fyllut-sendinn
+    url: https://nav-it.slack.com/archives/C04J0SGHQTD
   license:
     name: MIT License
     url: https://github.com/navikt/soknadsfillager/blob/main/LICENSE
@@ -219,7 +219,7 @@ paths:
 
         responses:
           '200':
-            description:
+            description: Data som kan brukes til å preutfylle verdier i fyllut
             content:
               application/json:
                 schema:
@@ -1331,6 +1331,8 @@ components:
           $ref: "#/components/schemas/Vedleggsnr"
         tittel:
           $ref: "#/components/schemas/Tittel"
+        url:
+          $ref: "#/components/schemas/Vedleggsurl"
 
     KanLasteOppAnnet:
       type: boolean
@@ -1806,6 +1808,11 @@ components:
       type: string
       description: NAVs identifikasjon av dokumenttype enten som Skjemanummer eller vedleggsnummer.
       example: NAV 14-35.01 eller T7
+
+    Vedleggsurl:
+      type: string
+      description: Noen vedlegg er NAV-skjemaer som brukeren må fylle ut først og laste det opp som vedlegg. Vedleggsurl er en lenke til skjemaet (enten PDF eller til fyllut) som brukeren kan laste ned/fylle ut.
+      example: https://cdn.sanity.io/files/gx9wf39f/soknadsveiviser-p/7146ae917cf8423f71edbf37369da5a6b2a23524.pdf
 
     Vedtaksinformasjon:
       type: object

--- a/api/src/main/resources/innsending-api.yml
+++ b/api/src/main/resources/innsending-api.yml
@@ -815,11 +815,17 @@ paths:
 
           responses:
             201:
-              description: Created
+              description: Opprettet ettersending
               content:
                 application/json:
                   schema:
                     $ref: "#/components/schemas/DokumentSoknadDto"
+            401:
+              description: Uautorisert
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/RestErrorResponseDto"
           tags:
             - ekstern
 
@@ -1111,7 +1117,7 @@ components:
     BrukernotifikasjonsType:
       type: string
       enum: [ "utkast", "oppgave" ]
-      description: "Hvilke type brukernotifkasjon som skal sendes. Default: utkast"
+      description: "Hvilke type brukernotifikasjon som skal sendes. Default: utkast"
       example: oppgave
 
     Document:
@@ -1221,7 +1227,7 @@ components:
           $ref: "#/components/schemas/Spraak"
         tema:
           $ref: "#/components/schemas/Tema"
-        brukernotifkasjonstype:
+        brukernotifikasjonstype:
           $ref: "#/components/schemas/BrukernotifikasjonsType"
         vedleggsListe:
           type: array
@@ -1533,6 +1539,22 @@ components:
       type: string
       description: Nøkkelnavn på property. Brukt på vedlegg av type Annet (skjemanr=N6), for å sjekke om dette er default Annet vedlegg eller ikke
       example: annenDokumentasjon,  tilleggsVedleggForSkjemaXX.
+
+    RestErrorResponseDto:
+      type: object
+      description: Feilrespons
+      properties:
+        message:
+          type: string
+          description: Feilmelding
+        timestamp:
+          type: string
+          format: date-time
+          description: Tidspunkt i UTC
+          example: 2021-12-03T14:10:00Z
+        errorCode:
+          type: string
+          description: Feilkode
 
     Saksinformasjon:
       type: object

--- a/api/src/main/resources/innsending-api.yml
+++ b/api/src/main/resources/innsending-api.yml
@@ -293,14 +293,14 @@ paths:
     post:
       summary: Kall for å opprette en ettersendingssøknad basert på et skjemanummer.
       description: På basis av oppgitt skjemanummer, blir det opprettet en ettersendingssøknad som inviterer søker til å laste opp vedlegg.
-      operationId: OpprettEttersending
+      operationId: opprettEttersendingGittSkjemanr
 
       requestBody:
         description: Data neccessary in order to publish a new task or message user notification.
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OpprettEttersending"
+              $ref: "#/components/schemas/OpprettEttersendingGittSkjemaNr"
         required: true
 
       responses:
@@ -1312,10 +1312,32 @@ components:
       enum: [ "IkkeValgt", "LastetOpp", "Innsendt", "SendSenere", "SendesAvAndre", "SendesIkke", "LastetOppIkkeRelevantLenger" ]
       description: Status på om et vedlegg til søknad er enda ikke er lastet opp, lastet opp eller innsendt
 
-
     OpprettEttersending:
       type: object
-      description: Data for å opprette en ettersending gitt skjemanummer
+      description: Data for å opprette en ettersending
+      required:
+        - tittel
+        - skjemanr
+        - sprak
+        - tema
+      properties:
+        tittel:
+          $ref: "#/components/schemas/Tittel"
+        skjemanr:
+          $ref: "#/components/schemas/Skjemanr"
+        sprak:
+          $ref: "#/components/schemas/Spraak"
+        tema:
+          $ref: "#/components/schemas/Tema"
+        vedleggsListe:
+          type: array
+          description: Liste av vedlegg som kan lastes opp
+          items:
+            $ref: "#/components/schemas/InnsendtVedleggDto"
+
+    OpprettEttersendingGittSkjemaNr:
+      type: object
+      description: Data for å opprette en søknad gitt skjemanummer
       required:
         - skjemanr
         - sprak
@@ -1328,7 +1350,7 @@ components:
           type: array
           description: Liste av vedlegg som kan lastes opp
           items:
-            $ref: "#/components/schemas/InnsendtVedleggDto"
+            $ref: "#/components/schemas/Vedleggsnr"
 
     OpprettSoknadBody:
       type: object

--- a/api/src/main/resources/innsending-api.yml
+++ b/api/src/main/resources/innsending-api.yml
@@ -293,14 +293,14 @@ paths:
     post:
       summary: Kall for å opprette en ettersendingssøknad basert på et skjemanummer.
       description: På basis av oppgitt skjemanummer, blir det opprettet en ettersendingssøknad som inviterer søker til å laste opp vedlegg.
-      operationId: opprettEttersendingGittSkjemanr
+      operationId: OpprettEttersending
 
       requestBody:
         description: Data neccessary in order to publish a new task or message user notification.
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OpprettEttersendingGittSkjemaNr"
+              $ref: "#/components/schemas/OpprettEttersending"
         required: true
 
       responses:
@@ -1312,18 +1312,10 @@ components:
       enum: [ "IkkeValgt", "LastetOpp", "Innsendt", "SendSenere", "SendesAvAndre", "SendesIkke", "LastetOppIkkeRelevantLenger" ]
       description: Status på om et vedlegg til søknad er enda ikke er lastet opp, lastet opp eller innsendt
 
-    OpprettEttersendingGittInnsendingsId:
-      type: object
-      description: Data for å angi hvilken søknad søker ønsker å ettersende på
-      required:
-        - ettersendingTilinnsendingsId
-      properties:
-        ettersendingTilinnsendingsId:
-          $ref: "#/components/schemas/InnsendingsId"
 
-    OpprettEttersendingGittSkjemaNr:
+    OpprettEttersending:
       type: object
-      description: Data for å opprette en søknad gitt skjemanummer
+      description: Data for å opprette en ettersending gitt skjemanummer
       required:
         - skjemanr
         - sprak
@@ -1336,7 +1328,7 @@ components:
           type: array
           description: Liste av vedlegg som kan lastes opp
           items:
-            $ref: "#/components/schemas/Vedleggsnr"
+            $ref: "#/components/schemas/InnsendtVedleggDto"
 
     OpprettSoknadBody:
       type: object

--- a/api/src/main/resources/innsending-api.yml
+++ b/api/src/main/resources/innsending-api.yml
@@ -803,7 +803,7 @@ paths:
 
   /ekstern/v1/ettersending:
         post:
-          summary: Kall for å opprette en ettersending fra eksterne applikasjoner
+          summary: Kall for å opprette en ettersending fra eksterne applikasjoner. Det er per nå ingen validering på skjemanr, tema, vedleggskode etc, så det innebærer at klienten har ansvar for at disse er gyldige.
           operationId: eksternOpprettEttersending
 
           requestBody:

--- a/api/src/main/resources/innsending-api.yml
+++ b/api/src/main/resources/innsending-api.yml
@@ -1242,6 +1242,10 @@ components:
           $ref: "#/components/schemas/Tema"
         brukernotifikasjonstype:
           $ref: "#/components/schemas/BrukernotifikasjonsType"
+        koblesTilEksisterendeSoknad:
+          type: boolean
+          description: "Angir om ettersendingen skal kobles til en eksisterende søknad. Hvis denne er satt til true vil filer som tidligere er lastet opp vises i send-inn. Default: false"
+          example: false
         vedleggsListe:
           type: array
           description: Liste av vedlegg som kan lastes opp

--- a/api/src/main/resources/innsending-api.yml
+++ b/api/src/main/resources/innsending-api.yml
@@ -24,6 +24,8 @@ tags:
     description: API for sendinn-frontend applikasjonen for å håndtere filer.
   - name: soknadsveiviser
     description: API for soknadsveiviser applikasjonen.
+  - name: ekstern
+    description: API for eksterne applikasjoner.
 
 paths:
   /fyllUt/v1/leggTilVedlegg:
@@ -327,7 +329,7 @@ paths:
 
         responses:
           201:
-            description: Created
+            description: Opprettet ettersending
             content:
               application/json:
                 schema:
@@ -799,6 +801,28 @@ paths:
       tags:
         - fyllut
 
+  /ekstern/v1/ettersending:
+        post:
+          summary: Kall for å opprette en ettersending fra eksterne applikasjoner
+          operationId: eksternOpprettEttersending
+
+          requestBody:
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/EksternOpprettEttersending"
+            required: true
+
+          responses:
+            201:
+              description: Created
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/DokumentSoknadDto"
+          tags:
+            - ekstern
+
   /health/ping:
     get:
       summary: Pings the application to see if it responds
@@ -1084,6 +1108,12 @@ components:
       description: Ident til søker som har opprettet søknad i fyllUt tjenesten.
       example: 12128012345
 
+    BrukernotifikasjonsType:
+      type: string
+      enum: [ "utkast", "oppgave" ]
+      description: "Hvilke type brukernotifkasjon som skal sendes. Default: utkast"
+      example: oppgave
+
     Document:
       type: string
       format: byte
@@ -1172,6 +1202,32 @@ components:
           default: false
         soknadstype:
           $ref: "#/components/schemas/SoknadType"
+
+    EksternOpprettEttersending:
+      type: object
+      description: Data for å opprette en ettersending
+      required:
+        - tittel
+        - skjemanr
+        - sprak
+        - tema
+        - vedleggsListe
+      properties:
+        tittel:
+          $ref: "#/components/schemas/Tittel"
+        skjemanr:
+          $ref: "#/components/schemas/Skjemanr"
+        sprak:
+          $ref: "#/components/schemas/Spraak"
+        tema:
+          $ref: "#/components/schemas/Tema"
+        brukernotifkasjonstype:
+          $ref: "#/components/schemas/BrukernotifikasjonsType"
+        vedleggsListe:
+          type: array
+          description: Liste av vedlegg som kan lastes opp
+          items:
+            $ref: "#/components/schemas/InnsendtVedleggDto"
 
     FilDto:
       type: object

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/dto/RestErrorResponseDto.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/dto/RestErrorResponseDto.kt
@@ -1,9 +1,0 @@
-package no.nav.soknad.innsending.dto
-
-import java.time.LocalDateTime
-
-data class RestErrorResponseDto(
-	val message: String,
-	val timeStamp: LocalDateTime,
-	val errorCode: String
-)

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/exceptions/RestExceptionHandler.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/exceptions/RestExceptionHandler.kt
@@ -3,14 +3,14 @@ package no.nav.soknad.innsending.exceptions
 import jakarta.servlet.http.HttpServletRequest
 import no.nav.security.token.support.core.exceptions.JwtTokenMissingException
 import no.nav.security.token.support.spring.validation.interceptor.JwtTokenUnauthorizedException
-import no.nav.soknad.innsending.dto.RestErrorResponseDto
+import no.nav.soknad.innsending.model.RestErrorResponseDto
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
-import java.time.LocalDateTime
+import java.time.OffsetDateTime
 
 
 @ControllerAdvice
@@ -24,9 +24,9 @@ class RestExceptionHandler {
 		logger.warn(exception.message, exception)
 		return ResponseEntity(
 			RestErrorResponseDto(
-				exception.message,
-				LocalDateTime.now(),
-				exception.errorCode.code
+				message = exception.message,
+				timestamp = OffsetDateTime.now(),
+				errorCode = exception.errorCode.code
 			), HttpStatus.NOT_FOUND
 		)
 	}
@@ -37,9 +37,9 @@ class RestExceptionHandler {
 		logger.error(exception.message, exception)
 		return ResponseEntity(
 			RestErrorResponseDto(
-				exception.message,
-				LocalDateTime.now(),
-				exception.errorCode.code
+				message = exception.message,
+				timestamp = OffsetDateTime.now(),
+				errorCode = exception.errorCode.code
 			), HttpStatus.INTERNAL_SERVER_ERROR
 		)
 	}
@@ -50,9 +50,9 @@ class RestExceptionHandler {
 		logger.warn(exception.message, exception)
 		return ResponseEntity(
 			RestErrorResponseDto(
-				exception.message,
-				LocalDateTime.now(),
-				exception.errorCode.code
+				message = exception.message,
+				timestamp = OffsetDateTime.now(),
+				errorCode = exception.errorCode.code
 			), HttpStatus.BAD_REQUEST
 		)
 	}
@@ -68,7 +68,7 @@ class RestExceptionHandler {
 		return ResponseEntity(
 			RestErrorResponseDto(
 				message = "Autentisering feilet",
-				timeStamp = LocalDateTime.now(),
+				timestamp = OffsetDateTime.now(),
 				errorCode = "errorCode.unauthorized"
 			), HttpStatus.UNAUTHORIZED
 		)
@@ -80,9 +80,9 @@ class RestExceptionHandler {
 		logger.error(exception.message, exception)
 		return ResponseEntity(
 			RestErrorResponseDto(
-				exception.message ?: "Noe gikk galt, prøv igjen senere",
-				LocalDateTime.now(),
-				ErrorCode.GENERAL_ERROR.code,
+				message = exception.message ?: "Noe gikk galt, prøv igjen senere",
+				timestamp = OffsetDateTime.now(),
+				errorCode = ErrorCode.GENERAL_ERROR.code,
 			), HttpStatus.INTERNAL_SERVER_ERROR
 		)
 	}

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/ekstern/EksternRestApi.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/ekstern/EksternRestApi.kt
@@ -31,7 +31,7 @@ class EksternRestApi(
 	override fun eksternOpprettEttersending(eksternOpprettEttersending: EksternOpprettEttersending): ResponseEntity<DokumentSoknadDto> {
 		val brukerId = tilgangskontroll.hentBrukerFraToken()
 		combinedLogger.log(
-			"Kall for å opprette ettersending på skjema ${eksternOpprettEttersending.skjemanr}",
+			"Kall for å opprette ettersending fra ekstern applikasjon på skjema ${eksternOpprettEttersending.skjemanr}",
 			brukerId
 		)
 
@@ -40,7 +40,7 @@ class EksternRestApi(
 			skjemanr = eksternOpprettEttersending.skjemanr,
 		)
 
-		val ettersending = ettersendingService.externalCreateEttersending(
+		val ettersending = ettersendingService.createEttersendingFromExternalApplication(
 			eksternOpprettEttersending = eksternOpprettEttersending,
 			brukerId = brukerId
 		)

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/ekstern/EksternRestApi.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/ekstern/EksternRestApi.kt
@@ -1,0 +1,47 @@
+package no.nav.soknad.innsending.rest.ekstern
+
+import no.nav.soknad.innsending.api.EksternApi
+import no.nav.soknad.innsending.model.DokumentSoknadDto
+import no.nav.soknad.innsending.model.EksternOpprettEttersending
+import no.nav.soknad.innsending.security.Tilgangskontroll
+import no.nav.soknad.innsending.service.EttersendingService
+import no.nav.soknad.innsending.util.logging.CombinedLogger
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+
+class EksternRestApi(
+	private val tilgangskontroll: Tilgangskontroll,
+	private val ettersendingService: EttersendingService,
+) : EksternApi {
+
+	private val logger = LoggerFactory.getLogger(javaClass)
+	private val secureLogger = LoggerFactory.getLogger("secureLogger")
+	private val combinedLogger = CombinedLogger(logger, secureLogger)
+
+	override fun eksternOpprettEttersending(eksternOpprettEttersending: EksternOpprettEttersending): ResponseEntity<DokumentSoknadDto> {
+		val brukerId = tilgangskontroll.hentBrukerFraToken()
+		combinedLogger.log(
+			"Kall for å opprette ettersending på skjema ${eksternOpprettEttersending.skjemanr}",
+			brukerId
+		)
+
+		// FIXME: Do we need to log warning if ettersending already exists?
+
+		val ettersending = ettersendingService.externalCreateEttersending(
+			eksternOpprettEttersending = eksternOpprettEttersending,
+			brukerId = brukerId
+		)
+
+		combinedLogger.log(
+			"${ettersending.innsendingsId}: Opprettet ettersending fra soknadsveiviser på skjema ${ettersending.skjemanr}",
+			brukerId
+		)
+
+		return ResponseEntity
+			.status(HttpStatus.CREATED)
+			.body(ettersending)
+	}
+
+
+}

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/ekstern/EksternRestApi.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/ekstern/EksternRestApi.kt
@@ -14,7 +14,11 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@ProtectedWithClaims(issuer = Constants.TOKENX, claimMap = [Constants.CLAIM_ACR_IDPORTEN_LOA_HIGH])
+@ProtectedWithClaims(
+	issuer = Constants.TOKENX,
+	claimMap = [Constants.CLAIM_ACR_LEVEL_4, Constants.CLAIM_ACR_IDPORTEN_LOA_HIGH],
+	combineWithOr = true
+)
 class EksternRestApi(
 	private val tilgangskontroll: Tilgangskontroll,
 	private val ettersendingService: EttersendingService,

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/ekstern/EksternRestApi.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/ekstern/EksternRestApi.kt
@@ -1,15 +1,20 @@
 package no.nav.soknad.innsending.rest.ekstern
 
+import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.soknad.innsending.api.EksternApi
 import no.nav.soknad.innsending.model.DokumentSoknadDto
 import no.nav.soknad.innsending.model.EksternOpprettEttersending
 import no.nav.soknad.innsending.security.Tilgangskontroll
 import no.nav.soknad.innsending.service.EttersendingService
+import no.nav.soknad.innsending.util.Constants
 import no.nav.soknad.innsending.util.logging.CombinedLogger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RestController
 
+@RestController
+@ProtectedWithClaims(issuer = Constants.TOKENX, claimMap = [Constants.CLAIM_ACR_IDPORTEN_LOA_HIGH])
 class EksternRestApi(
 	private val tilgangskontroll: Tilgangskontroll,
 	private val ettersendingService: EttersendingService,
@@ -26,7 +31,10 @@ class EksternRestApi(
 			brukerId
 		)
 
-		// FIXME: Do we need to log warning if ettersending already exists?
+		ettersendingService.logWarningForExistingEttersendelse(
+			brukerId = brukerId,
+			skjemanr = eksternOpprettEttersending.skjemanr,
+		)
 
 		val ettersending = ettersendingService.externalCreateEttersending(
 			eksternOpprettEttersending = eksternOpprettEttersending,
@@ -34,7 +42,7 @@ class EksternRestApi(
 		)
 
 		combinedLogger.log(
-			"${ettersending.innsendingsId}: Opprettet ettersending fra soknadsveiviser på skjema ${ettersending.skjemanr}",
+			"${ettersending.innsendingsId}: Opprettet ettersending fra ekstern applikasjon på skjema ${ettersending.skjemanr}",
 			brukerId
 		)
 

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/ettersending/EttersendingRestApi.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/ettersending/EttersendingRestApi.kt
@@ -32,7 +32,7 @@ class EttersendingRestApi(
 	override fun opprettEttersending(opprettEttersending: OpprettEttersending): ResponseEntity<DokumentSoknadDto> {
 		val brukerId = tilgangskontroll.hentBrukerFraToken()
 		combinedLogger.log(
-			"Kall for å opprette ettersending på skjema ${opprettEttersending.skjemanr}",
+			"Kall for å opprette ettersending fra fyllut-ettersending på skjema ${opprettEttersending.skjemanr}",
 			brukerId
 		)
 

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/ettersending/EttersendingRestApi.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/ettersending/EttersendingRestApi.kt
@@ -41,7 +41,7 @@ class EttersendingRestApi(
 			skjemanr = opprettEttersending.skjemanr,
 		)
 
-		val ettersending = ettersendingService.createEttersendingFromExistingSoknader(
+		val ettersending = ettersendingService.createEttersendingFromFyllutEttersending(
 			ettersending = opprettEttersending,
 			brukerId = brukerId
 		)

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/ettersending/EttersendingRestApi.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/ettersending/EttersendingRestApi.kt
@@ -12,11 +12,9 @@ import no.nav.soknad.innsending.util.logging.CombinedLogger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@CrossOrigin(maxAge = 3600)
 @ProtectedWithClaims(issuer = Constants.TOKENX, claimMap = [Constants.CLAIM_ACR_IDPORTEN_LOA_HIGH])
 class EttersendingRestApi(
 	private val tilgangskontroll: Tilgangskontroll,
@@ -34,7 +32,10 @@ class EttersendingRestApi(
 			brukerId
 		)
 
-		// FIXME: Do we need to log warning if ettersending already exists?
+		ettersendingService.logWarningForExistingEttersendelse(
+			brukerId = brukerId,
+			skjemanr = opprettEttersending.skjemanr,
+		)
 
 		val ettersending = ettersendingService.createEttersendingFromExistingSoknader(
 			ettersending = opprettEttersending,
@@ -42,7 +43,7 @@ class EttersendingRestApi(
 		)
 
 		combinedLogger.log(
-			"${ettersending.innsendingsId}: Opprettet ettersending fra soknadsveiviser på skjema ${ettersending.skjemanr}",
+			"${ettersending.innsendingsId}: Opprettet ettersending fra fyllut-ettersending på skjema ${ettersending.skjemanr}",
 			brukerId
 		)
 

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/soknadsveiviser/SoknadsveiviserRestApi.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/soknadsveiviser/SoknadsveiviserRestApi.kt
@@ -4,7 +4,7 @@ package no.nav.soknad.innsending.rest.soknadsveiviser
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.soknad.innsending.api.SoknadsveiviserApi
 import no.nav.soknad.innsending.model.DokumentSoknadDto
-import no.nav.soknad.innsending.model.OpprettEttersending
+import no.nav.soknad.innsending.model.OpprettEttersendingGittSkjemaNr
 import no.nav.soknad.innsending.model.OpprettSoknadBody
 import no.nav.soknad.innsending.security.Tilgangskontroll
 import no.nav.soknad.innsending.service.EttersendingService
@@ -61,31 +61,31 @@ class SoknadsveiviserRestApi(
 	}
 
 	@Timed(InnsenderOperation.OPPRETT)
-	override fun opprettEttersending(ettersending: OpprettEttersending): ResponseEntity<DokumentSoknadDto> {
+	override fun opprettEttersendingGittSkjemanr(opprettEttersendingGittSkjemaNr: OpprettEttersendingGittSkjemaNr): ResponseEntity<DokumentSoknadDto> {
 		val brukerId = tilgangskontroll.hentBrukerFraToken()
 		combinedLogger.log(
-			"Kall for å opprette ettersending på skjema ${ettersending.skjemanr}",
+			"Kall for å opprette ettersending på skjema ${opprettEttersendingGittSkjemaNr.skjemanr}",
 			brukerId
 		)
 
 		ettersendingService.logWarningForExistingEttersendelse(
 			brukerId = brukerId,
-			skjemanr = ettersending.skjemanr,
+			skjemanr = opprettEttersendingGittSkjemaNr.skjemanr,
 		)
 
-		val createdEttersending = ettersendingService.createEttersendingFromExistingSoknader(
-			ettersending = ettersending,
+		val ettersending = ettersendingService.createEttersendingFromExistingSoknaderUsingSanity(
+			opprettEttersendingGittSkjemaNr = opprettEttersendingGittSkjemaNr,
 			brukerId = brukerId
 		)
 
 		combinedLogger.log(
-			"${createdEttersending.innsendingsId}: Opprettet ettersending på skjema ${createdEttersending.skjemanr}",
+			"${ettersending.innsendingsId}: Opprettet ettersending på skjema ${ettersending.skjemanr}",
 			brukerId
 		)
 
 		return ResponseEntity
 			.status(HttpStatus.CREATED)
-			.body(createdEttersending)
+			.body(ettersending)
 	}
 
 }

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/soknadsveiviser/SoknadsveiviserRestApi.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/soknadsveiviser/SoknadsveiviserRestApi.kt
@@ -79,7 +79,7 @@ class SoknadsveiviserRestApi(
 		)
 
 		combinedLogger.log(
-			"${ettersending.innsendingsId}: Opprettet ettersending på skjema ${ettersending.skjemanr}",
+			"${ettersending.innsendingsId}: Opprettet ettersending fra soknadsveiviser på skjema ${ettersending.skjemanr}",
 			brukerId
 		)
 

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/soknadsveiviser/SoknadsveiviserRestApi.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/soknadsveiviser/SoknadsveiviserRestApi.kt
@@ -1,19 +1,17 @@
-package no.nav.soknad.innsending.rest.ettersending
+package no.nav.soknad.innsending.rest.soknadsveiviser
 
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.soknad.innsending.api.SoknadsveiviserApi
 import no.nav.soknad.innsending.model.DokumentSoknadDto
-import no.nav.soknad.innsending.model.OpprettEttersendingGittSkjemaNr
+import no.nav.soknad.innsending.model.OpprettEttersending
 import no.nav.soknad.innsending.model.OpprettSoknadBody
 import no.nav.soknad.innsending.security.Tilgangskontroll
 import no.nav.soknad.innsending.service.EttersendingService
-import no.nav.soknad.innsending.service.SafService
 import no.nav.soknad.innsending.service.SoknadService
 import no.nav.soknad.innsending.supervision.InnsenderOperation
 import no.nav.soknad.innsending.supervision.timer.Timed
 import no.nav.soknad.innsending.util.Constants
-import no.nav.soknad.innsending.util.Constants.MAX_AKTIVE_DAGER
 import no.nav.soknad.innsending.util.finnSpraakFraInput
 import no.nav.soknad.innsending.util.logging.CombinedLogger
 import org.slf4j.LoggerFactory
@@ -21,7 +19,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.RestController
-import java.time.OffsetDateTime
 
 // Soknadsveiviser (old dokumentinnsending) creates a link to sendinn-frontend with query parameters to create a new soknad/ettersendelse
 // Since soknadsveiviser is deprecated and will be removed, it is separated from the sendinn folder
@@ -32,7 +29,6 @@ class SoknadsveiviserRestApi(
 	private val soknadService: SoknadService,
 	private val tilgangskontroll: Tilgangskontroll,
 	private val ettersendingService: EttersendingService,
-	private val safService: SafService,
 ) : SoknadsveiviserApi {
 
 	private val logger = LoggerFactory.getLogger(javaClass)
@@ -65,50 +61,31 @@ class SoknadsveiviserRestApi(
 	}
 
 	@Timed(InnsenderOperation.OPPRETT)
-	override fun opprettEttersendingGittSkjemanr(opprettEttersendingGittSkjemaNr: OpprettEttersendingGittSkjemaNr): ResponseEntity<DokumentSoknadDto> {
+	override fun opprettEttersending(ettersending: OpprettEttersending): ResponseEntity<DokumentSoknadDto> {
 		val brukerId = tilgangskontroll.hentBrukerFraToken()
 		combinedLogger.log(
-			"Kall for å opprette ettersending på skjema ${opprettEttersendingGittSkjemaNr.skjemanr}",
+			"Kall for å opprette ettersending på skjema ${ettersending.skjemanr}",
 			brukerId
 		)
 
-		ettersendingService.loggWarningVedEksisterendeEttersendelse(
-			brukerId,
-			opprettEttersendingGittSkjemaNr.skjemanr,
+		ettersendingService.logWarningForExistingEttersendelse(
+			brukerId = brukerId,
+			skjemanr = ettersending.skjemanr,
 		)
 
-		val arkiverteSoknader = safService.hentInnsendteSoknader(brukerId)
-			.filter { opprettEttersendingGittSkjemaNr.skjemanr == it.skjemanr && it.innsendingsId != null }
-			.filter { it.innsendtDato.isAfter(OffsetDateTime.now().minusDays(MAX_AKTIVE_DAGER)) }
-			.sortedByDescending { it.innsendtDato }
-		val innsendteSoknader =
-			try {
-				soknadService.hentInnsendteSoknader(tilgangskontroll.hentPersonIdents())
-					.filter { it.skjemanr == opprettEttersendingGittSkjemaNr.skjemanr }
-					.filter { it.innsendtDato!!.isAfter(OffsetDateTime.now().minusDays(MAX_AKTIVE_DAGER)) }
-					.sortedByDescending { it.innsendtDato }
-			} catch (e: Exception) {
-				logger.info("Ingen søknader funnet i basen for bruker på skjemanr = ${opprettEttersendingGittSkjemaNr.skjemanr}")
-				emptyList()
-			}
-
-		logger.info("Gitt skjemaNr ${opprettEttersendingGittSkjemaNr.skjemanr}: Antall innsendteSoknader=${innsendteSoknader.size} og Antall arkiverteSoknader=${arkiverteSoknader.size}")
-		val dokumentSoknadDto =
-			ettersendingService.opprettDokumentSoknadDto(
-				innsendteSoknader = innsendteSoknader,
-				arkiverteSoknader = arkiverteSoknader,
-				brukerId = brukerId,
-				opprettEttersendingGittSkjemaNr = opprettEttersendingGittSkjemaNr
-			)
+		val createdEttersending = ettersendingService.createEttersendingFromExistingSoknader(
+			ettersending = ettersending,
+			brukerId = brukerId
+		)
 
 		combinedLogger.log(
-			"${dokumentSoknadDto.innsendingsId}: Opprettet ettersending på skjema ${opprettEttersendingGittSkjemaNr.skjemanr}",
+			"${createdEttersending.innsendingsId}: Opprettet ettersending på skjema ${createdEttersending.skjemanr}",
 			brukerId
 		)
 
 		return ResponseEntity
 			.status(HttpStatus.CREATED)
-			.body(dokumentSoknadDto)
+			.body(createdEttersending)
 	}
 
 }

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/soknadsveiviser/SoknadsveiviserRestApi.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/soknadsveiviser/SoknadsveiviserRestApi.kt
@@ -68,7 +68,7 @@ class SoknadsveiviserRestApi(
 	override fun opprettEttersendingGittSkjemanr(opprettEttersendingGittSkjemaNr: OpprettEttersendingGittSkjemaNr): ResponseEntity<DokumentSoknadDto> {
 		val brukerId = tilgangskontroll.hentBrukerFraToken()
 		combinedLogger.log(
-			"Kall for å opprette ettersending på skjema ${opprettEttersendingGittSkjemaNr.skjemanr}",
+			"Kall for å opprette ettersending fra soknadsveiviser (via sendinn) på skjema ${opprettEttersendingGittSkjemaNr.skjemanr}",
 			brukerId
 		)
 
@@ -83,7 +83,7 @@ class SoknadsveiviserRestApi(
 		)
 
 		combinedLogger.log(
-			"${ettersending.innsendingsId}: Opprettet ettersending fra soknadsveiviser på skjema ${ettersending.skjemanr}",
+			"${ettersending.innsendingsId}: Opprettet ettersending fra soknadsveiviser (via sendinn) på skjema ${ettersending.skjemanr}",
 			brukerId
 		)
 

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/service/EttersendingService.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/service/EttersendingService.kt
@@ -350,7 +350,7 @@ class EttersendingService(
 	): DokumentSoknadDto {
 		val ettersending = mapToOpprettEttersending(eksternOpprettEttersending)
 
-		return if (eksternOpprettEttersending.brukernotifkasjonstype == BrukernotifikasjonsType.oppgave) {
+		return if (eksternOpprettEttersending.brukernotifikasjonstype == BrukernotifikasjonsType.oppgave) {
 			createEttersendingFromExistingSoknader(brukerId = brukerId, ettersending = ettersending, erSystemGenerert = true)
 		} else {
 			createEttersendingFromExistingSoknader(brukerId = brukerId, ettersending = ettersending)

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/service/EttersendingService.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/service/EttersendingService.kt
@@ -343,7 +343,7 @@ class EttersendingService(
 		}
 	}
 
-	//
+	// Create an ettersending from external application
 	fun externalCreateEttersending(
 		brukerId: String,
 		eksternOpprettEttersending: EksternOpprettEttersending
@@ -375,14 +375,14 @@ class EttersendingService(
 
 		if (erSystemGenerert == true) {
 			publiserBrukernotifikasjon(dokumentSoknadDto.copy(erSystemGenerert = true))
+		} else {
+			publiserBrukernotifikasjon(dokumentSoknadDto)
 		}
-
-		publiserBrukernotifikasjon(dokumentSoknadDto)
 
 		return dokumentSoknadDto
 	}
 
-	// Gets info from Sanity before creating an ettersending
+	// Get info from Sanity before creating an ettersending
 	fun createEttersendingFromExistingSoknaderUsingSanity(
 		brukerId: String,
 		opprettEttersendingGittSkjemaNr: OpprettEttersendingGittSkjemaNr

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/service/EttersendingService.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/service/EttersendingService.kt
@@ -342,8 +342,7 @@ class EttersendingService(
 		}
 	}
 
-	// Create an ettersending from external application
-	fun externalCreateEttersending(
+	fun createEttersendingFromExternalApplication(
 		brukerId: String,
 		eksternOpprettEttersending: EksternOpprettEttersending
 	): DokumentSoknadDto {

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/service/SoknadService.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/service/SoknadService.kt
@@ -63,7 +63,7 @@ class SoknadService(
 			// Lagre soknadens hovedvedlegg
 			val skjemaDbData = vedleggService.opprettHovedddokumentVedlegg(savedSoknadDbData, kodeverkSkjema)
 
-			val vedleggDbDataListe = vedleggService.opprettVedleggTilSoknad(savedSoknadDbData.id!!, vedleggsnrListe, spraak)
+			val vedleggDbDataListe = vedleggService.saveVedlegg(savedSoknadDbData.id!!, vedleggsnrListe, spraak)
 
 			val savedVedleggDbDataListe = listOf(skjemaDbData) + vedleggDbDataListe
 

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/service/VedleggService.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/service/VedleggService.kt
@@ -77,7 +77,7 @@ class VedleggService(
 					opprettetdato = LocalDateTime.now(),
 					endretdato = LocalDateTime.now(),
 					innsendtdato = null,
-					vedleggsurl = null,
+					vedleggsurl = it.url,
 					formioid = null
 				)
 			)
@@ -141,11 +141,7 @@ class VedleggService(
 					opprettetdato = v.opprettetdato.toLocalDateTime(),
 					endretdato = LocalDateTime.now(),
 					innsendtdato = v.innsendtdato?.toLocalDateTime(),
-					vedleggsurl = if (v.vedleggsnr != null) skjemaService.hentSkjema(
-						v.vedleggsnr!!,
-						soknadDbData.spraak ?: "nb",
-						false
-					).url else null,
+					vedleggsurl = v.skjemaurl,
 					formioid = v.formioId
 				)
 			)
@@ -381,6 +377,7 @@ class VedleggService(
 			InnsendtVedleggDto(
 				tittel = kodeverkSkjema.tittel ?: "",
 				vedleggsnr = vedleggsnr,
+				url = kodeverkSkjema.url
 			)
 		}
 	}

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/util/mapping/Ettersending.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/util/mapping/Ettersending.kt
@@ -1,0 +1,14 @@
+package no.nav.soknad.innsending.util.mapping
+
+import no.nav.soknad.innsending.model.EksternOpprettEttersending
+import no.nav.soknad.innsending.model.OpprettEttersending
+
+fun mapToOpprettEttersending(eksternOpprettEttersending: EksternOpprettEttersending): OpprettEttersending {
+	return OpprettEttersending(
+		tittel = eksternOpprettEttersending.tittel,
+		skjemanr = eksternOpprettEttersending.skjemanr,
+		sprak = eksternOpprettEttersending.sprak,
+		tema = eksternOpprettEttersending.tema,
+		vedleggsListe = eksternOpprettEttersending.vedleggsListe
+	)
+}

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/rest/ekstern/EksternRestApiTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/rest/ekstern/EksternRestApiTest.kt
@@ -1,0 +1,90 @@
+package no.nav.soknad.innsending.rest.ekstern
+
+import com.ninjasquad.springmockk.SpykBean
+import io.mockk.slot
+import io.mockk.verify
+import no.nav.security.mock.oauth2.MockOAuth2Server
+import no.nav.soknad.arkivering.soknadsmottaker.model.AddNotification
+import no.nav.soknad.innsending.ApplicationTest
+import no.nav.soknad.innsending.consumerapis.brukernotifikasjonpublisher.PublisherInterface
+import no.nav.soknad.innsending.model.BrukernotifikasjonsType
+import no.nav.soknad.innsending.utils.Api
+import no.nav.soknad.innsending.utils.builders.ettersending.EksternOpprettEttersendingTestBuilder
+import no.nav.soknad.innsending.utils.builders.ettersending.InnsendtVedleggDtoTestBuilder
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.web.client.TestRestTemplate
+
+class EksternRestApiTest : ApplicationTest() {
+	@Autowired
+	lateinit var mockOAuth2Server: MockOAuth2Server
+
+	@Autowired
+	lateinit var restTemplate: TestRestTemplate
+
+	@SpykBean()
+	lateinit var publisherInterface: PublisherInterface
+
+	@Value("\${server.port}")
+	var serverPort: Int? = 9064
+
+	var api: Api? = null
+
+	@BeforeEach
+	fun setup() {
+		api = Api(restTemplate, serverPort!!, mockOAuth2Server)
+	}
+
+	@Test
+	fun `Should create ettersending with utkast brukernotifikasjon (default)`() {
+		// Given
+		val skjemanr = "NAV 55-00.60"
+		val tema = "DAG"
+		val vedleggsnr = "A1"
+
+		val ettersending = EksternOpprettEttersendingTestBuilder()
+			.skjemanr(skjemanr)
+			.tema(tema)
+			.vedleggsListe(listOf(InnsendtVedleggDtoTestBuilder().vedleggsnr(vedleggsnr).build()))
+			.build()
+
+		// When
+		val response = api?.createEksternEttersending(ettersending)
+
+		val message = slot<AddNotification>()
+		verify(exactly = 1) { publisherInterface.opprettBrukernotifikasjon(capture(message)) }
+
+		// Then
+		assertNotNull(response?.body)
+
+		val body = response!!.body!!
+		assertEquals(skjemanr, body.skjemanr)
+		assertEquals(tema, body.tema)
+		assertEquals(1, body.vedleggsListe.size)
+		assertEquals(vedleggsnr, body.vedleggsListe[0].vedleggsnr)
+
+		assertEquals(false, message.captured.soknadRef.erSystemGenerert)
+	}
+
+	@Test
+	fun `Should create ettersending with oppgave brukernotifikasjon`() {
+		// Given
+		val ettersending = EksternOpprettEttersendingTestBuilder()
+			.brukernotifkasjonstype(BrukernotifikasjonsType.oppgave)
+			.build()
+
+		// When
+		api?.createEksternEttersending(ettersending)
+
+		val message = slot<AddNotification>()
+		verify { publisherInterface.opprettBrukernotifikasjon(capture(message)) }
+
+		// Then
+		// The notification is an oppgave if erSystemGenerert is true
+		assertEquals(true, message.captured.soknadRef.erSystemGenerert)
+	}
+}

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/rest/ekstern/EksternRestApiTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/rest/ekstern/EksternRestApiTest.kt
@@ -74,7 +74,7 @@ class EksternRestApiTest : ApplicationTest() {
 	fun `Should create ettersending with oppgave brukernotifikasjon`() {
 		// Given
 		val ettersending = EksternOpprettEttersendingTestBuilder()
-			.brukernotifkasjonstype(BrukernotifikasjonsType.oppgave)
+			.brukernotifikasjonstype(BrukernotifikasjonsType.oppgave)
 			.build()
 
 		// When

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/rest/ettersending/EttersendingRestApiTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/rest/ettersending/EttersendingRestApiTest.kt
@@ -1,0 +1,90 @@
+package no.nav.soknad.innsending.rest.ettersending
+
+import no.nav.security.mock.oauth2.MockOAuth2Server
+import no.nav.soknad.innsending.ApplicationTest
+import no.nav.soknad.innsending.utils.Api
+import no.nav.soknad.innsending.utils.builders.SkjemaDtoTestBuilder
+import no.nav.soknad.innsending.utils.builders.ettersending.InnsendtVedleggDtoTestBuilder
+import no.nav.soknad.innsending.utils.builders.ettersending.OpprettEttersendingTestBuilder
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.web.client.TestRestTemplate
+
+class EttersendingRestApiTest : ApplicationTest() {
+
+	@Autowired
+	lateinit var mockOAuth2Server: MockOAuth2Server
+
+	@Autowired
+	lateinit var restTemplate: TestRestTemplate
+
+	@Value("\${server.port}")
+	var serverPort: Int? = 9064
+
+	var api: Api? = null
+
+	@BeforeEach
+	fun setup() {
+		api = Api(restTemplate, serverPort!!, mockOAuth2Server)
+	}
+
+	@Test
+	fun `Should create ettersending with no existing søknader`() {
+		// Given
+		val skjemanr = "NAV 55-00.60"
+		val tema = "DAG"
+		val vedleggsnr = "A1"
+
+		val ettersending = OpprettEttersendingTestBuilder()
+			.skjemanr(skjemanr)
+			.tema(tema)
+			.vedleggsListe(listOf(InnsendtVedleggDtoTestBuilder().vedleggsnr(vedleggsnr).build()))
+			.build()
+
+		// When
+		val response = api?.createEttersending(ettersending)
+
+		// Then
+		assertNotNull(response?.body)
+
+		val body = response!!.body!!
+		assertEquals(skjemanr, body.skjemanr)
+		assertEquals(tema, body.tema)
+		assertEquals(1, body.vedleggsListe.size)
+		assertEquals(vedleggsnr, body.vedleggsListe[0].vedleggsnr)
+	}
+
+	@Test
+	fun `Should create ettersending with existing søknad`() {
+		// Given
+		val vedleggsnr = "A1"
+		val skjemaDto = SkjemaDtoTestBuilder().build()
+
+		val opprettetSoknadResponse = api?.createSoknad(skjemaDto)
+		val innsendingsId = opprettetSoknadResponse?.body?.innsendingsId!!
+
+		api?.utfyltSoknad(innsendingsId, skjemaDto)
+		api?.sendInnSoknad(innsendingsId)
+
+		val ettersending = OpprettEttersendingTestBuilder()
+			.skjemanr(skjemaDto.skjemanr)
+			.vedleggsListe(listOf(InnsendtVedleggDtoTestBuilder().vedleggsnr(vedleggsnr).build()))
+			.build()
+
+		// When
+		val response = api?.createEttersending(ettersending)
+
+		// Then
+		assertNotNull(response?.body)
+
+		val body = response!!.body!!
+		assertEquals(1, body.vedleggsListe.size)
+		assertEquals(innsendingsId, body.ettersendingsId, "Should have ettersendingId from existing søknad innsendingsId")
+		assertEquals(vedleggsnr, body.vedleggsListe[0].vedleggsnr)
+	}
+
+}

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/rest/fyllut/FyllutRestApiTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/rest/fyllut/FyllutRestApiTest.kt
@@ -2,7 +2,6 @@ package no.nav.soknad.innsending.rest.fyllut
 
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.soknad.innsending.ApplicationTest
-import no.nav.soknad.innsending.dto.RestErrorResponseDto
 import no.nav.soknad.innsending.exceptions.ErrorCode
 import no.nav.soknad.innsending.exceptions.ResourceNotFoundException
 import no.nav.soknad.innsending.model.*

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/service/EttersendingServiceTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/service/EttersendingServiceTest.kt
@@ -322,9 +322,19 @@ class EttersendingServiceTest : ApplicationTest() {
 		val soknader = soknadService.hentAktiveSoknader(listOf(dokumentSoknadDto.brukerId))
 		assertTrue(soknader.isNotEmpty())
 
+		val ettersending = OpprettEttersendingTestBuilder()
+			.skjemanr(dokumentSoknadDto.skjemanr)
+			.vedleggsListe(
+				listOf(
+					InnsendtVedleggDtoTestBuilder().vedleggsnr("W1").tittel("Vedlegg1").build(),
+					InnsendtVedleggDtoTestBuilder().vedleggsnr("W2").tittel("Vedlegg2").build()
+				)
+			)
+			.build()
+
 		// Oppretter ettersendingssoknad
 		val ettersendingsSoknadDto =
-			ettersendingService.opprettEttersending(dokumentSoknadDto.brukerId, dokumentSoknadDto.innsendingsId!!)
+			ettersendingService.createEttersendingFromExistingSoknader(dokumentSoknadDto.brukerId, ettersending)
 
 		assertTrue(ettersendingsSoknadDto.vedleggsListe.isNotEmpty())
 		assertTrue(ettersendingsSoknadDto.vedleggsListe.any { it.opplastingsStatus == OpplastingsStatusDto.ikkeValgt })
@@ -361,7 +371,7 @@ class EttersendingServiceTest : ApplicationTest() {
 
 		// Oppretter ettersendingssoknad2
 		val ettersendingsSoknadDto2 =
-			ettersendingService.opprettEttersending(dokumentSoknadDto.brukerId, dokumentSoknadDto.innsendingsId!!)
+			ettersendingService.createEttersendingFromExistingSoknader(dokumentSoknadDto.brukerId, ettersending)
 
 		assertTrue(ettersendingsSoknadDto2.vedleggsListe.isNotEmpty())
 		assertTrue(ettersendingsSoknadDto2.vedleggsListe.any { it.opplastingsStatus == OpplastingsStatusDto.ikkeValgt })
@@ -436,9 +446,18 @@ class EttersendingServiceTest : ApplicationTest() {
 		assertEquals(HendelseType.Opprettet, hendelseDbDatasInnsendt[0].hendelsetype)
 		assertEquals(HendelseType.Innsendt, hendelseDbDatasInnsendt[1].hendelsetype)
 
+		val ettersending = OpprettEttersendingTestBuilder()
+			.skjemanr(dokumentSoknadDto.skjemanr)
+			.vedleggsListe(
+				listOf(
+					InnsendtVedleggDtoTestBuilder().vedleggsnr("W1").tittel("Vedlegg1").build(),
+					InnsendtVedleggDtoTestBuilder().vedleggsnr("W2").tittel("Vedlegg2").build(),
+				)
+			).build()
+
 		// Opprett ettersendingssoknad
 		val ettersendingsSoknadDto =
-			ettersendingService.opprettEttersending(dokumentSoknadDto.brukerId, dokumentSoknadDto.innsendingsId!!)
+			ettersendingService.createEttersendingFromExistingSoknader(dokumentSoknadDto.brukerId, ettersending)
 
 		assertTrue(ettersendingsSoknadDto.vedleggsListe.isNotEmpty())
 		assertTrue(ettersendingsSoknadDto.vedleggsListe.none { it.opplastingsStatus == OpplastingsStatusDto.innsendt })

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/service/EttersendingServiceTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/service/EttersendingServiceTest.kt
@@ -168,7 +168,6 @@ class EttersendingServiceTest : ApplicationTest() {
 		val brukerid = testpersonid
 		val skjemanr = "NAV 10-07.20"
 		val tittel = "Test av ettersending gitt arkivertsoknad"
-		val spraak = "nb_NO"
 		val tema = "HJE"
 		val arkivertInnsendingsId = "1234567890123345"
 		val arkivertSoknad = AktivSakDto(

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/service/InnsendingServiceTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/service/InnsendingServiceTest.kt
@@ -16,6 +16,8 @@ import no.nav.soknad.innsending.model.SoknadFile
 import no.nav.soknad.innsending.supervision.InnsenderMetrics
 import no.nav.soknad.innsending.utils.Hjelpemetoder
 import no.nav.soknad.innsending.utils.SoknadAssertions
+import no.nav.soknad.innsending.utils.builders.ettersending.InnsendtVedleggDtoTestBuilder
+import no.nav.soknad.innsending.utils.builders.ettersending.OpprettEttersendingTestBuilder
 import no.nav.soknad.pdfutilities.AntallSider
 import no.nav.soknad.pdfutilities.PdfGenerator
 import org.junit.jupiter.api.Assertions
@@ -152,8 +154,17 @@ class InnsendingServiceTest : ApplicationTest() {
 		Assertions.assertTrue(kvitteringsDto.innsendteVedlegg!!.isEmpty())
 		Assertions.assertTrue(kvitteringsDto.skalEttersendes!!.isNotEmpty())
 
+		val ettersending = OpprettEttersendingTestBuilder()
+			.skjemanr(dokumentSoknadDto.skjemanr)
+			.vedleggsListe(
+				listOf(
+					InnsendtVedleggDtoTestBuilder().vedleggsnr("W1").tittel("Vedlegg1").build(),
+				)
+			)
+			.build()
+
 		val ettersendingsSoknadDto =
-			ettersendingService.opprettEttersending(dokumentSoknadDto.brukerId, dokumentSoknadDto.innsendingsId!!)
+			ettersendingService.createEttersendingFromExistingSoknader(dokumentSoknadDto.brukerId, ettersending)
 
 		Assertions.assertTrue(ettersendingsSoknadDto.vedleggsListe.isNotEmpty())
 		Assertions.assertTrue(ettersendingsSoknadDto.vedleggsListe.any { it.opplastingsStatus == OpplastingsStatusDto.ikkeValgt })
@@ -223,9 +234,18 @@ class InnsendingServiceTest : ApplicationTest() {
 		Assertions.assertTrue(kvitteringsDto.innsendteVedlegg!!.isEmpty())
 		Assertions.assertTrue(kvitteringsDto.skalEttersendes!!.isNotEmpty())
 
+		val ettersending = OpprettEttersendingTestBuilder()
+			.skjemanr(dokumentSoknadDto.skjemanr)
+			.vedleggsListe(
+				listOf(
+					InnsendtVedleggDtoTestBuilder().vedleggsnr("W1").tittel("Vedlegg1").build(),
+				)
+			)
+			.build()
+
 		// Opprett ettersendingssoknad
 		val ettersendingsSoknadDto =
-			ettersendingService.opprettEttersending(dokumentSoknadDto.brukerId, dokumentSoknadDto.innsendingsId!!)
+			ettersendingService.createEttersendingFromExistingSoknader(dokumentSoknadDto.brukerId, ettersending)
 
 		Assertions.assertTrue(ettersendingsSoknadDto.vedleggsListe.isNotEmpty())
 		Assertions.assertTrue(ettersendingsSoknadDto.vedleggsListe.none { it.opplastingsStatus == OpplastingsStatusDto.innsendt })

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/service/SoknadServiceTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/service/SoknadServiceTest.kt
@@ -32,6 +32,8 @@ import no.nav.soknad.innsending.utils.Hjelpemetoder
 import no.nav.soknad.innsending.utils.SoknadAssertions
 import no.nav.soknad.innsending.utils.builders.DokumentSoknadDtoTestBuilder
 import no.nav.soknad.innsending.utils.builders.VedleggDtoTestBuilder
+import no.nav.soknad.innsending.utils.builders.ettersending.InnsendtVedleggDtoTestBuilder
+import no.nav.soknad.innsending.utils.builders.ettersending.OpprettEttersendingTestBuilder
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -265,11 +267,14 @@ class SoknadServiceTest : ApplicationTest() {
 			innsendtVedleggDtos = arkiverteVedlegg
 		)
 
-		val ettersending = ettersendingService.opprettEttersendingGittArkivertSoknad(
+		val opprettEttersending =
+			OpprettEttersendingTestBuilder().vedleggsListe(listOf(InnsendtVedleggDtoTestBuilder().build())).build()
+
+		val ettersending = ettersendingService.createEttersendingFromArchivedSoknad(
 			brukerId = "1234",
-			arkivertSoknad = arkivertSoknad,
-			"no_NO",
-			listOf("W1")
+			archivedSoknad = arkivertSoknad,
+			opprettEttersending,
+			null
 		)
 
 		assertNotNull(ettersending)

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/service/SoknadServiceTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/service/SoknadServiceTest.kt
@@ -273,8 +273,8 @@ class SoknadServiceTest : ApplicationTest() {
 		val ettersending = ettersendingService.createEttersendingFromArchivedSoknad(
 			brukerId = "1234",
 			archivedSoknad = arkivertSoknad,
-			opprettEttersending,
-			null
+			ettersending = opprettEttersending,
+			forsteInnsendingsDato = null
 		)
 
 		assertNotNull(ettersending)

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/utils/Api.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/utils/Api.kt
@@ -154,6 +154,24 @@ class Api(val restTemplate: TestRestTemplate, val serverPort: Int, val mockOAuth
 		)
 	}
 
+	fun createEttersending(opprettEttersending: OpprettEttersending): ResponseEntity<DokumentSoknadDto> {
+		return restTemplate.exchange(
+			"${baseUrl}/frontend/v1/ettersending",
+			HttpMethod.POST,
+			createHttpEntity(opprettEttersending),
+			DokumentSoknadDto::class.java
+		)
+	}
+
+	fun createEksternEttersending(eksternOpprettEttersending: EksternOpprettEttersending): ResponseEntity<DokumentSoknadDto> {
+		return restTemplate.exchange(
+			"${baseUrl}/ekstern/v1/ettersending",
+			HttpMethod.POST,
+			createHttpEntity(eksternOpprettEttersending),
+			DokumentSoknadDto::class.java
+		)
+	}
+
 	fun getPrefillData(properties: String): ResponseEntity<PrefillData>? {
 		return restTemplate.exchange(
 			"${baseUrl}/fyllUt/v1/prefill-data?properties=$properties",

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/utils/Api.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/utils/Api.kt
@@ -155,7 +155,7 @@ class Api(val restTemplate: TestRestTemplate, val serverPort: Int, val mockOAuth
 
 	fun createEttersending(opprettEttersending: OpprettEttersending): ResponseEntity<DokumentSoknadDto> {
 		return restTemplate.exchange(
-			"${baseUrl}/frontend/v1/ettersending",
+			"${baseUrl}/fyllut/v1/ettersending",
 			HttpMethod.POST,
 			createHttpEntity(opprettEttersending),
 			DokumentSoknadDto::class.java

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/utils/Api.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/utils/Api.kt
@@ -1,7 +1,6 @@
 package no.nav.soknad.innsending.utils
 
 import no.nav.security.mock.oauth2.MockOAuth2Server
-import no.nav.soknad.innsending.dto.RestErrorResponseDto
 import no.nav.soknad.innsending.model.*
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.core.ParameterizedTypeReference

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/utils/builders/ettersending/EksternOpprettEttersendingTestBuilder.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/utils/builders/ettersending/EksternOpprettEttersendingTestBuilder.kt
@@ -12,6 +12,7 @@ class EksternOpprettEttersendingTestBuilder {
 	private var tema = "FOS"
 	private var tittel = "Ettersendingssøknad tittel"
 	private var brukernotifikasjonstype = BrukernotifikasjonsType.utkast
+	private var koblesTilEksisterendeSoknad = false
 
 	fun skjemanr(skjemanr: String) = apply { this.skjemanr = skjemanr }
 	fun sprak(sprak: String) = apply { this.sprak = sprak }
@@ -21,6 +22,9 @@ class EksternOpprettEttersendingTestBuilder {
 	fun brukernotifikasjonstype(brukernotifikasjonstype: BrukernotifikasjonsType) =
 		apply { this.brukernotifikasjonstype = brukernotifikasjonstype }
 
+	fun koblesTilEksisterendeSoknad(koblesTilEksisterendeSoknad: Boolean) =
+		apply { this.koblesTilEksisterendeSoknad = koblesTilEksisterendeSoknad }
+
 	fun build(): EksternOpprettEttersending {
 		return EksternOpprettEttersending(
 			skjemanr = skjemanr,
@@ -29,6 +33,7 @@ class EksternOpprettEttersendingTestBuilder {
 			tema = tema,
 			tittel = tittel,
 			brukernotifikasjonstype = brukernotifikasjonstype,
+			koblesTilEksisterendeSoknad = koblesTilEksisterendeSoknad
 		)
 	}
 }

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/utils/builders/ettersending/EksternOpprettEttersendingTestBuilder.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/utils/builders/ettersending/EksternOpprettEttersendingTestBuilder.kt
@@ -1,0 +1,34 @@
+package no.nav.soknad.innsending.utils.builders.ettersending
+
+import no.nav.soknad.innsending.model.BrukernotifikasjonsType
+import no.nav.soknad.innsending.model.EksternOpprettEttersending
+import no.nav.soknad.innsending.model.InnsendtVedleggDto
+import java.util.*
+
+class EksternOpprettEttersendingTestBuilder {
+	private var skjemanr: String = "NAV-${UUID.randomUUID().toString().take(4)}"
+	private var sprak: String = "nb_NO"
+	private var vedleggsListe: List<InnsendtVedleggDto> = listOf(InnsendtVedleggDtoTestBuilder().build())
+	private var tema = "FOS"
+	private var tittel = "Ettersendingssøknad tittel"
+	private var brukernotifkasjonstype = BrukernotifikasjonsType.utkast
+
+	fun skjemanr(skjemanr: String) = apply { this.skjemanr = skjemanr }
+	fun sprak(sprak: String) = apply { this.sprak = sprak }
+	fun vedleggsListe(vedleggsListe: List<InnsendtVedleggDto>) = apply { this.vedleggsListe = vedleggsListe }
+	fun tema(tema: String) = apply { this.tema = tema }
+	fun tittel(titel: String) = apply { this.tittel = titel }
+	fun brukernotifkasjonstype(brukernotifkasjonstype: BrukernotifikasjonsType) =
+		apply { this.brukernotifkasjonstype = brukernotifkasjonstype }
+
+	fun build(): EksternOpprettEttersending {
+		return EksternOpprettEttersending(
+			skjemanr = skjemanr,
+			sprak = sprak,
+			vedleggsListe = vedleggsListe,
+			tema = tema,
+			tittel = tittel,
+			brukernotifkasjonstype = brukernotifkasjonstype,
+		)
+	}
+}

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/utils/builders/ettersending/EksternOpprettEttersendingTestBuilder.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/utils/builders/ettersending/EksternOpprettEttersendingTestBuilder.kt
@@ -11,15 +11,15 @@ class EksternOpprettEttersendingTestBuilder {
 	private var vedleggsListe: List<InnsendtVedleggDto> = listOf(InnsendtVedleggDtoTestBuilder().build())
 	private var tema = "FOS"
 	private var tittel = "Ettersendingssøknad tittel"
-	private var brukernotifkasjonstype = BrukernotifikasjonsType.utkast
+	private var brukernotifikasjonstype = BrukernotifikasjonsType.utkast
 
 	fun skjemanr(skjemanr: String) = apply { this.skjemanr = skjemanr }
 	fun sprak(sprak: String) = apply { this.sprak = sprak }
 	fun vedleggsListe(vedleggsListe: List<InnsendtVedleggDto>) = apply { this.vedleggsListe = vedleggsListe }
 	fun tema(tema: String) = apply { this.tema = tema }
 	fun tittel(titel: String) = apply { this.tittel = titel }
-	fun brukernotifkasjonstype(brukernotifkasjonstype: BrukernotifikasjonsType) =
-		apply { this.brukernotifkasjonstype = brukernotifkasjonstype }
+	fun brukernotifikasjonstype(brukernotifikasjonstype: BrukernotifikasjonsType) =
+		apply { this.brukernotifikasjonstype = brukernotifikasjonstype }
 
 	fun build(): EksternOpprettEttersending {
 		return EksternOpprettEttersending(
@@ -28,7 +28,7 @@ class EksternOpprettEttersendingTestBuilder {
 			vedleggsListe = vedleggsListe,
 			tema = tema,
 			tittel = tittel,
-			brukernotifkasjonstype = brukernotifkasjonstype,
+			brukernotifikasjonstype = brukernotifikasjonstype,
 		)
 	}
 }

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/utils/builders/ettersending/InnsendtVedleggDtoTestBuilder.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/utils/builders/ettersending/InnsendtVedleggDtoTestBuilder.kt
@@ -1,0 +1,18 @@
+package no.nav.soknad.innsending.utils.builders.ettersending
+
+import no.nav.soknad.innsending.model.InnsendtVedleggDto
+
+class InnsendtVedleggDtoTestBuilder {
+	private var vedleggsnr: String = "${('A'..'Z').random()}${(1..9).random()}"
+	private var tittel: String = "Vedleggstittel"
+
+	fun vedleggsnr(vedleggsnr: String) = apply { this.vedleggsnr = vedleggsnr }
+	fun tittel(tittel: String) = apply { this.tittel = tittel }
+
+	fun build(): InnsendtVedleggDto {
+		return InnsendtVedleggDto(
+			vedleggsnr = vedleggsnr,
+			tittel = tittel
+		)
+	}
+}

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/utils/builders/ettersending/OpprettEttersendingTestBuilder.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/utils/builders/ettersending/OpprettEttersendingTestBuilder.kt
@@ -8,16 +8,23 @@ class OpprettEttersendingTestBuilder {
 	private var skjemanr: String = "NAV-${UUID.randomUUID().toString().take(4)}"
 	private var sprak: String = "nb_NO"
 	private var vedleggsListe: List<InnsendtVedleggDto>? = emptyList()
+	private var tema = "FOS"
+	private var tittel = "Ettersendingssøknad tittel"
 
 	fun skjemanr(skjemanr: String) = apply { this.skjemanr = skjemanr }
 	fun sprak(sprak: String) = apply { this.sprak = sprak }
 	fun vedleggsListe(vedleggsListe: List<InnsendtVedleggDto>) = apply { this.vedleggsListe = vedleggsListe }
 
+	fun tema(tema: String) = apply { this.tema = tema }
+	fun tittel(titel: String) = apply { this.tittel = titel }
+
 	fun build(): OpprettEttersending {
 		return OpprettEttersending(
 			skjemanr = skjemanr,
 			sprak = sprak,
-			vedleggsListe = vedleggsListe
+			vedleggsListe = vedleggsListe,
+			tema = tema,
+			tittel = tittel
 		)
 	}
 }

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/utils/builders/ettersending/OpprettEttersendingTestBuilder.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/utils/builders/ettersending/OpprettEttersendingTestBuilder.kt
@@ -1,0 +1,23 @@
+package no.nav.soknad.innsending.utils.builders.ettersending
+
+import no.nav.soknad.innsending.model.InnsendtVedleggDto
+import no.nav.soknad.innsending.model.OpprettEttersending
+import java.util.*
+
+class OpprettEttersendingTestBuilder {
+	private var skjemanr: String = "NAV-${UUID.randomUUID().toString().take(4)}"
+	private var sprak: String = "nb_NO"
+	private var vedleggsListe: List<InnsendtVedleggDto>? = emptyList()
+
+	fun skjemanr(skjemanr: String) = apply { this.skjemanr = skjemanr }
+	fun sprak(sprak: String) = apply { this.sprak = sprak }
+	fun vedleggsListe(vedleggsListe: List<InnsendtVedleggDto>) = apply { this.vedleggsListe = vedleggsListe }
+
+	fun build(): OpprettEttersending {
+		return OpprettEttersending(
+			skjemanr = skjemanr,
+			sprak = sprak,
+			vedleggsListe = vedleggsListe
+		)
+	}
+}

--- a/innsender/src/test/resources/mappings/pdlIdenterOk.json
+++ b/innsender/src/test/resources/mappings/pdlIdenterOk.json
@@ -31,6 +31,11 @@
 							"ident": "12345678902",
 							"gruppe": "FOLKEREGISTERIDENT",
 							"historisk": "true"
+						},
+						{
+							"ident": "19876898104",
+							"gruppe": "FOLKEREGISTERIDENT",
+							"historisk": "true"
 						}
 					]
 				}


### PR DESCRIPTION
`/ekstern/v1/ettersending` used for external applications
Custom options that are different from ettersendings-endpoint:
- `brukernotifikasjonstype`: `oppgave`/`utkast`
- `koblesTilEksisterendeSoknad`: If the ettersending should be linked to an existing søknad or not

`/fyllut/v1/ettersending` used by `fyllut-ettersending` application