### PR TITLE
Don't log client aborts as errors

### DIFF
--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/exceptions/RestExceptionHandler.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/exceptions/RestExceptionHandler.kt
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest
 import no.nav.security.token.support.core.exceptions.JwtTokenMissingException
 import no.nav.security.token.support.spring.validation.interceptor.JwtTokenUnauthorizedException
 import no.nav.soknad.innsending.model.RestErrorResponseDto
+import org.apache.catalina.connector.ClientAbortException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -79,6 +80,19 @@ class RestExceptionHandler {
 	@ExceptionHandler
 	fun generalException(exception: Exception): ResponseEntity<RestErrorResponseDto> {
 		logger.error(exception.message, exception)
+		return ResponseEntity(
+			RestErrorResponseDto(
+				message = exception.message ?: "Noe gikk galt, prøv igjen senere",
+				timestamp = OffsetDateTime.now(),
+				errorCode = ErrorCode.GENERAL_ERROR.code,
+			), HttpStatus.INTERNAL_SERVER_ERROR
+		)
+	}
+
+	// If client aborts we don't want to log this as an error
+	@ExceptionHandler
+	fun clientAbortException(exception: ClientAbortException): ResponseEntity<RestErrorResponseDto> {
+		logger.warn(exception.message, exception)
 		return ResponseEntity(
 			RestErrorResponseDto(
 				message = exception.message ?: "Noe gikk galt, prøv igjen senere",


### PR DESCRIPTION
The client won't see the response, but we need to return something