### PR TITLE
Brukernotifikasjoner

### DIFF
--- a/api/src/main/resources/innsending-api.yml
+++ b/api/src/main/resources/innsending-api.yml
@@ -367,6 +367,12 @@ paths:
       description: På basis av oppgitt skjemanummer og eventuelle vedlegg, blir det opprettet en søknad som inviterer søker til å laste ned skjema for utfylling og opplasting av dette og eventuelle vedlegg.
       operationId: opprettSoknad
 
+      parameters:
+        - in: header
+          name: Nav-Env-Qualifier
+          schema:
+            $ref: "#/components/schemas/EnvQualifier"
+
       requestBody:
         description: Data neccessary in order to publish a new task or message user notification.
         content:
@@ -391,6 +397,12 @@ paths:
       summary: Kall for å opprette en ettersendingssøknad basert på et skjemanummer.
       description: På basis av oppgitt skjemanummer, blir det opprettet en ettersendingssøknad som inviterer søker til å laste opp vedlegg.
       operationId: opprettEttersendingGittSkjemanr
+
+      parameters:
+        - in: header
+          name: Nav-Env-Qualifier
+          schema:
+            $ref: "#/components/schemas/EnvQualifier"
 
       requestBody:
         description: Data neccessary in order to publish a new task or message user notification.

--- a/api/src/main/resources/innsending-api.yml
+++ b/api/src/main/resources/innsending-api.yml
@@ -170,6 +170,10 @@ paths:
               required: false
               schema:
                 type: boolean
+            - in: header
+              name: Nav-Env-Qualifier
+              schema:
+                $ref: "#/components/schemas/EnvQualifier"
 
       responses:
         200:
@@ -826,6 +830,10 @@ paths:
           schema:
             type: string
           style: simple
+        - in: header
+          name: Nav-Env-Qualifier
+          schema:
+            $ref: "#/components/schemas/EnvQualifier"
 
       responses:
         200:
@@ -883,6 +891,10 @@ paths:
               required: false
               schema:
                 type: string
+            - in: header
+              name: Nav-Env-Qualifier
+              schema:
+                $ref: "#/components/schemas/EnvQualifier"
           requestBody:
             content:
               application/json:

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/cleanup/FjernGamleSoknader.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/cleanup/FjernGamleSoknader.kt
@@ -1,5 +1,6 @@
 package no.nav.soknad.innsending.cleanup
 
+import no.nav.soknad.innsending.service.NotificationService
 import no.nav.soknad.innsending.service.SoknadService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -10,6 +11,7 @@ import java.time.OffsetDateTime
 @Service
 class FjernGamleSoknader(
 	private val soknadService: SoknadService,
+	private val notificationService: NotificationService,
 	private val leaderSelectionUtility: LeaderSelectionUtility
 ) {
 
@@ -19,7 +21,10 @@ class FjernGamleSoknader(
 	fun fjernGamleIkkeInnsendteSoknader() {
 		try {
 			if (leaderSelectionUtility.isLeader()) {
-				soknadService.deleteSoknadBeforeCutoffDate(OffsetDateTime.now())
+				val innsendingsIdListe = soknadService.deleteSoknadBeforeCutoffDate(OffsetDateTime.now())
+				innsendingsIdListe.forEach {
+					notificationService.close(it)
+				}
 			}
 		} catch (ex: Exception) {
 			logger.warn("Fjerning av gamle ikke innsendte søknader feilet med ${ex.message}")

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/config/BrukerNotifikasjonConfig.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/config/BrukerNotifikasjonConfig.kt
@@ -5,8 +5,5 @@ import kotlin.properties.Delegates
 
 @ConfigurationProperties(prefix = "brukernotifikasjonconfig")
 class BrukerNotifikasjonConfig {
-	lateinit var fyllutUrl: String
-	lateinit var sendinnUrl: String
 	var publisereEndringer by Delegates.notNull<Boolean>()
-
 }

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/config/RestConfig.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/config/RestConfig.kt
@@ -16,6 +16,7 @@ class RestConfig {
 	lateinit var soknadsMottakerHost: String
 	lateinit var sendInnUrl: String
 	lateinit var sendinn: SendInnConfig
+	lateinit var fyllut: FyllutConfig
 	lateinit var fyllUtUrl: String
 	lateinit var pdlScope: String
 	lateinit var pdlUrl: String
@@ -27,6 +28,10 @@ class RestConfig {
 	lateinit var kontoregisterUrl: String
 
 	class SendInnConfig {
+		lateinit var urls: Map<String, String>
+	}
+
+	class FyllutConfig {
 		lateinit var urls: Map<String, String>
 	}
 }

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/db/StartDb.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/db/StartDb.kt
@@ -1,6 +1,7 @@
 package no.nav.soknad.innsending.db
 
 import com.opentable.db.postgres.embedded.EmbeddedPostgres
+import jakarta.annotation.PreDestroy
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
@@ -15,6 +16,11 @@ class StartDb {
 	@Bean
 	fun embeddedPostgres(): DataSource {
 		return embeddedPostgres.postgresDatabase
+	}
+
+	@PreDestroy
+	fun preDestroy() {
+		embeddedPostgres.close()
 	}
 
 }

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/location/UrlHandler.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/location/UrlHandler.kt
@@ -4,4 +4,5 @@ import no.nav.soknad.innsending.model.EnvQualifier
 
 interface UrlHandler {
 	fun getSendInnUrl(envQualifier: EnvQualifier? = null): String
+	fun getFyllutUrl(envQualifier: EnvQualifier? = null): String
 }

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/location/UrlHandlerDevImpl.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/location/UrlHandlerDevImpl.kt
@@ -18,4 +18,13 @@ class UrlHandlerDevImpl(
 			else -> defaultUrl
 		}
 	}
+
+	override fun getFyllutUrl(envQualifier: EnvQualifier?): String {
+		val urls = urlConfig.fyllut.urls
+		val defaultUrl = urls["default"].orEmpty()
+		return when {
+			envQualifier != null -> urls[envQualifier.value] ?: defaultUrl
+			else -> defaultUrl
+		}
+	}
 }

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/location/UrlHandlerImpl.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/location/UrlHandlerImpl.kt
@@ -12,4 +12,7 @@ class UrlHandlerImpl(
 ) : UrlHandler {
 	override fun getSendInnUrl(@Suppress("UNUSED_PARAMETER") envQualifier: EnvQualifier?): String =
 		urlConfig.sendinn.urls["default"].orEmpty()
+
+	override fun getFyllutUrl(@Suppress("UNUSED_PARAMETER") envQualifier: EnvQualifier?): String =
+		urlConfig.fyllUtUrl
 }

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/ekstern/EksternRestApi.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/ekstern/EksternRestApi.kt
@@ -7,6 +7,7 @@ import no.nav.soknad.innsending.model.BodyStatusResponseDto
 import no.nav.soknad.innsending.model.BrukernotifikasjonsType
 import no.nav.soknad.innsending.model.DokumentSoknadDto
 import no.nav.soknad.innsending.model.EksternOpprettEttersending
+import no.nav.soknad.innsending.model.EnvQualifier
 import no.nav.soknad.innsending.model.SoknadType
 import no.nav.soknad.innsending.security.SubjectHandlerInterface
 import no.nav.soknad.innsending.security.Tilgangskontroll
@@ -41,6 +42,7 @@ class EksternRestApi(
 	override fun eksternOpprettEttersending(
 		eksternOpprettEttersending: EksternOpprettEttersending,
 		navCallId: String?,
+		envQualifier: EnvQualifier?,
 	): ResponseEntity<DokumentSoknadDto> {
 		val brukerId = tilgangskontroll.hentBrukerFraToken()
 		val applikasjon = subjectHandler.getClientId()
@@ -61,8 +63,8 @@ class EksternRestApi(
 		)
 
 		val notificationOpts = NotificationOptions(
-			erSystemGenerert = eksternOpprettEttersending.brukernotifikasjonstype == BrukernotifikasjonsType.oppgave
-			// TODO envQualifier
+			erSystemGenerert = eksternOpprettEttersending.brukernotifikasjonstype == BrukernotifikasjonsType.oppgave,
+			envQualifier = envQualifier
 		)
 		notificationService.create(ettersending.innsendingsId!!, notificationOpts)
 

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/ettersending/EttersendingRestApi.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/ettersending/EttersendingRestApi.kt
@@ -9,6 +9,7 @@ import no.nav.soknad.innsending.model.EnvQualifier
 import no.nav.soknad.innsending.model.OpprettEttersending
 import no.nav.soknad.innsending.security.Tilgangskontroll
 import no.nav.soknad.innsending.service.EttersendingService
+import no.nav.soknad.innsending.service.NotificationService
 import no.nav.soknad.innsending.util.Constants
 import no.nav.soknad.innsending.util.logging.CombinedLogger
 import org.slf4j.LoggerFactory
@@ -26,6 +27,7 @@ import java.net.URI
 class EttersendingRestApi(
 	private val tilgangskontroll: Tilgangskontroll,
 	private val ettersendingService: EttersendingService,
+	private val notificationService: NotificationService,
 	private val urlHandler: UrlHandler,
 ) : EttersendingApi {
 
@@ -57,6 +59,9 @@ class EttersendingRestApi(
 			"${ettersending.innsendingsId}: Opprettet ettersending fra fyllut-ettersending på skjema ${ettersending.skjemanr}",
 			brukerId
 		)
+
+		// TODO envQualifier
+		notificationService.create(ettersending.innsendingsId!!)
 
 		return ResponseEntity
 			.status(HttpStatus.CREATED)

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/ettersending/EttersendingRestApi.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/ettersending/EttersendingRestApi.kt
@@ -3,6 +3,7 @@ package no.nav.soknad.innsending.rest.ettersending
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.soknad.innsending.api.EttersendingApi
+import no.nav.soknad.innsending.brukernotifikasjon.NotificationOptions
 import no.nav.soknad.innsending.location.UrlHandler
 import no.nav.soknad.innsending.model.DokumentSoknadDto
 import no.nav.soknad.innsending.model.EnvQualifier
@@ -60,8 +61,7 @@ class EttersendingRestApi(
 			brukerId
 		)
 
-		// TODO envQualifier
-		notificationService.create(ettersending.innsendingsId!!)
+		notificationService.create(ettersending.innsendingsId!!, NotificationOptions(envQualifier = envQualifier))
 
 		return ResponseEntity
 			.status(HttpStatus.CREATED)

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/fyllut/FyllutRestApi.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/fyllut/FyllutRestApi.kt
@@ -2,6 +2,7 @@ package no.nav.soknad.innsending.rest.fyllut
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.soknad.innsending.api.FyllutApi
+import no.nav.soknad.innsending.brukernotifikasjon.NotificationOptions
 import no.nav.soknad.innsending.exceptions.ErrorCode
 import no.nav.soknad.innsending.exceptions.IllegalActionException
 import no.nav.soknad.innsending.location.UrlHandler
@@ -46,7 +47,8 @@ class FyllutRestApi(
 	@Timed(InnsenderOperation.OPPRETT)
 	override fun fyllUtOpprettSoknad(
 		skjemaDto: SkjemaDto,
-		force: Boolean?
+		force: Boolean?,
+		envQualifier: EnvQualifier?,
 	): ResponseEntity<Any> {
 		val brukerId = tilgangskontroll.hentBrukerFraToken()
 		val applikasjon = subjectHandler.getClientId()
@@ -72,8 +74,7 @@ class FyllutRestApi(
 			"${opprettetSoknad.innsendingsId}: Soknad fra FyllUt opprettet",
 			brukerId
 		)
-		// TODO envQualifier
-		notificationService.create(opprettetSoknad.innsendingsId!!)
+		notificationService.create(opprettetSoknad.innsendingsId!!, NotificationOptions(envQualifier = envQualifier))
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(opprettetSoknad)
 	}

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/fyllut/FyllutRestApi.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/fyllut/FyllutRestApi.kt
@@ -9,6 +9,7 @@ import no.nav.soknad.innsending.model.*
 import no.nav.soknad.innsending.security.SubjectHandlerInterface
 import no.nav.soknad.innsending.security.Tilgangskontroll
 import no.nav.soknad.innsending.service.ArenaService
+import no.nav.soknad.innsending.service.NotificationService
 import no.nav.soknad.innsending.service.PrefillService
 import no.nav.soknad.innsending.service.SoknadService
 import no.nav.soknad.innsending.supervision.InnsenderOperation
@@ -34,7 +35,8 @@ class FyllutRestApi(
 	private val tilgangskontroll: Tilgangskontroll,
 	private val prefillService: PrefillService,
 	private val subjectHandler: SubjectHandlerInterface,
-	private val arenaService: ArenaService
+	private val arenaService: ArenaService,
+	private val notificationService: NotificationService,
 ) : FyllutApi {
 
 	private val logger = LoggerFactory.getLogger(javaClass)
@@ -70,6 +72,8 @@ class FyllutRestApi(
 			"${opprettetSoknad.innsendingsId}: Soknad fra FyllUt opprettet",
 			brukerId
 		)
+		// TODO envQualifier
+		notificationService.create(opprettetSoknad.innsendingsId!!)
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(opprettetSoknad)
 	}
@@ -172,6 +176,7 @@ class FyllutRestApi(
 		val dokumentSoknadDto = soknadService.hentSoknad(innsendingsId)
 		validerSoknadsTilgang(dokumentSoknadDto)
 
+		notificationService.close(innsendingsId)
 		soknadService.slettSoknadAvBruker(dokumentSoknadDto)
 		combinedLogger.log("$innsendingsId: Slettet søknad", brukerId)
 

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/sendinn/SoknadRestApi.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/sendinn/SoknadRestApi.kt
@@ -7,6 +7,7 @@ import no.nav.soknad.innsending.exceptions.ErrorCode
 import no.nav.soknad.innsending.exceptions.IllegalActionException
 import no.nav.soknad.innsending.model.BodyStatusResponseDto
 import no.nav.soknad.innsending.model.DokumentSoknadDto
+import no.nav.soknad.innsending.model.EnvQualifier
 import no.nav.soknad.innsending.model.KvitteringsDto
 import no.nav.soknad.innsending.model.PatchSoknadDto
 import no.nav.soknad.innsending.security.Tilgangskontroll
@@ -87,7 +88,10 @@ class SoknadRestApi(
 	}
 
 	@Timed(InnsenderOperation.SEND_INN)
-	override fun sendInnSoknad(innsendingsId: String): ResponseEntity<KvitteringsDto> {
+	override fun sendInnSoknad(
+		innsendingsId: String,
+		envQualifier: EnvQualifier?,
+	): ResponseEntity<KvitteringsDto> {
 		val brukerId = tilgangskontroll.hentBrukerFraToken()
 
 		combinedLogger.log("$innsendingsId: Kall for å sende inn soknad", brukerId)
@@ -104,8 +108,10 @@ class SoknadRestApi(
 		)
 
 		if (ettersending != null) {
-			// TODO envQualifier
-			notificationService.create(ettersending.innsendingsId!!, NotificationOptions(erSystemGenerert = true))
+			notificationService.create(
+				ettersending.innsendingsId!!,
+				NotificationOptions(erSystemGenerert = true, envQualifier = envQualifier)
+			)
 		}
 
 		return ResponseEntity

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/soknadsveiviser/SoknadsveiviserRestApi.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/soknadsveiviser/SoknadsveiviserRestApi.kt
@@ -3,7 +3,9 @@ package no.nav.soknad.innsending.rest.soknadsveiviser
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.soknad.innsending.api.SoknadsveiviserApi
+import no.nav.soknad.innsending.brukernotifikasjon.NotificationOptions
 import no.nav.soknad.innsending.model.DokumentSoknadDto
+import no.nav.soknad.innsending.model.EnvQualifier
 import no.nav.soknad.innsending.model.OpprettEttersendingGittSkjemaNr
 import no.nav.soknad.innsending.model.OpprettSoknadBody
 import no.nav.soknad.innsending.security.Tilgangskontroll
@@ -42,10 +44,13 @@ class SoknadsveiviserRestApi(
 	private val combinedLogger = CombinedLogger(logger, secureLogger)
 
 	@Timed(InnsenderOperation.OPPRETT)
-	override fun opprettSoknad(opprettSoknadBody: OpprettSoknadBody): ResponseEntity<DokumentSoknadDto> {
+	override fun opprettSoknad(
+		opprettSoknadBody: OpprettSoknadBody,
+		envQualifier: EnvQualifier?,
+	): ResponseEntity<DokumentSoknadDto> {
 		val brukerId = tilgangskontroll.hentBrukerFraToken()
 
-		combinedLogger.log("Skal opprette søknad for ${opprettSoknadBody.skjemanr}", brukerId)
+		combinedLogger.log("Skal opprette søknad for ${opprettSoknadBody.skjemanr} ($envQualifier)", brukerId)
 
 		soknadService.loggWarningVedEksisterendeSoknad(brukerId, opprettSoknadBody.skjemanr)
 
@@ -61,7 +66,7 @@ class SoknadsveiviserRestApi(
 			brukerId
 		)
 
-		notificationService.create(dokumentSoknadDto.innsendingsId!!)
+		notificationService.create(dokumentSoknadDto.innsendingsId!!, NotificationOptions(envQualifier = envQualifier))
 
 		return ResponseEntity
 			.status(HttpStatus.CREATED)
@@ -69,10 +74,13 @@ class SoknadsveiviserRestApi(
 	}
 
 	@Timed(InnsenderOperation.OPPRETT)
-	override fun opprettEttersendingGittSkjemanr(opprettEttersendingGittSkjemaNr: OpprettEttersendingGittSkjemaNr): ResponseEntity<DokumentSoknadDto> {
+	override fun opprettEttersendingGittSkjemanr(
+		opprettEttersendingGittSkjemaNr: OpprettEttersendingGittSkjemaNr,
+		envQualifier: EnvQualifier?,
+	): ResponseEntity<DokumentSoknadDto> {
 		val brukerId = tilgangskontroll.hentBrukerFraToken()
 		combinedLogger.log(
-			"Kall for å opprette ettersending fra soknadsveiviser (via sendinn) på skjema ${opprettEttersendingGittSkjemaNr.skjemanr}",
+			"Kall for å opprette ettersending fra soknadsveiviser (via sendinn) på skjema ${opprettEttersendingGittSkjemaNr.skjemanr} ($envQualifier)",
 			brukerId
 		)
 
@@ -90,7 +98,7 @@ class SoknadsveiviserRestApi(
 			"${ettersending.innsendingsId}: Opprettet ettersending fra soknadsveiviser (via sendinn) på skjema ${ettersending.skjemanr}",
 			brukerId
 		)
-		notificationService.create(ettersending.innsendingsId!!)
+		notificationService.create(ettersending.innsendingsId!!, NotificationOptions(envQualifier = envQualifier))
 
 		return ResponseEntity
 			.status(HttpStatus.CREATED)

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/soknadsveiviser/SoknadsveiviserRestApi.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/rest/soknadsveiviser/SoknadsveiviserRestApi.kt
@@ -8,6 +8,7 @@ import no.nav.soknad.innsending.model.OpprettEttersendingGittSkjemaNr
 import no.nav.soknad.innsending.model.OpprettSoknadBody
 import no.nav.soknad.innsending.security.Tilgangskontroll
 import no.nav.soknad.innsending.service.EttersendingService
+import no.nav.soknad.innsending.service.NotificationService
 import no.nav.soknad.innsending.service.SoknadService
 import no.nav.soknad.innsending.supervision.InnsenderOperation
 import no.nav.soknad.innsending.supervision.timer.Timed
@@ -33,6 +34,7 @@ class SoknadsveiviserRestApi(
 	private val soknadService: SoknadService,
 	private val tilgangskontroll: Tilgangskontroll,
 	private val ettersendingService: EttersendingService,
+	private val notificationService: NotificationService,
 ) : SoknadsveiviserApi {
 
 	private val logger = LoggerFactory.getLogger(javaClass)
@@ -58,6 +60,8 @@ class SoknadsveiviserRestApi(
 			"${dokumentSoknadDto.innsendingsId}: Opprettet søknad på skjema ${opprettSoknadBody.skjemanr}",
 			brukerId
 		)
+
+		notificationService.create(dokumentSoknadDto.innsendingsId!!)
 
 		return ResponseEntity
 			.status(HttpStatus.CREATED)
@@ -86,6 +90,7 @@ class SoknadsveiviserRestApi(
 			"${ettersending.innsendingsId}: Opprettet ettersending fra soknadsveiviser (via sendinn) på skjema ${ettersending.skjemanr}",
 			brukerId
 		)
+		notificationService.create(ettersending.innsendingsId!!)
 
 		return ResponseEntity
 			.status(HttpStatus.CREATED)

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/service/LospostService.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/service/LospostService.kt
@@ -1,7 +1,5 @@
 package no.nav.soknad.innsending.service
 
-import no.nav.soknad.innsending.brukernotifikasjon.BrukernotifikasjonPublisher
-import no.nav.soknad.innsending.exceptions.BackendErrorException
 import no.nav.soknad.innsending.model.LospostDto
 import no.nav.soknad.innsending.model.VisningsType
 import no.nav.soknad.innsending.repository.domain.enums.ArkiveringsStatus
@@ -13,7 +11,6 @@ import no.nav.soknad.innsending.security.SubjectHandlerInterface
 import no.nav.soknad.innsending.util.Constants
 import no.nav.soknad.innsending.util.Utilities
 import no.nav.soknad.innsending.util.finnSpraakFraInput
-import no.nav.soknad.innsending.util.mapping.lagDokumentSoknadDto
 import no.nav.soknad.innsending.util.mapping.mapTilLospost
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -25,7 +22,6 @@ import java.util.*
 class LospostService(
 	private val repo: RepositoryUtils,
 	private val subjectHandler: SubjectHandlerInterface,
-	private val brukernotifikasjon: BrukernotifikasjonPublisher
 ) {
 
 	@Transactional
@@ -85,15 +81,6 @@ class LospostService(
 				opplastingsvalgkommentarledetekst = null,
 			)
 		)
-		try {
-			val dokumentSoknadDto = lagDokumentSoknadDto(soknad, listOf(vedlegg))
-			brukernotifikasjon.soknadStatusChange(dokumentSoknadDto)
-		} catch (e: Exception) {
-			throw BackendErrorException(
-				"$innsendingsId: Feil under opprettelse av brukernotifikasjon i forbindelse med løspost",
-				e
-			)
-		}
 		return mapTilLospost(soknad, vedlegg)
 	}
 

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/service/NotificationService.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/service/NotificationService.kt
@@ -1,0 +1,32 @@
+package no.nav.soknad.innsending.service
+
+import no.nav.soknad.innsending.brukernotifikasjon.BrukernotifikasjonPublisher
+import no.nav.soknad.innsending.brukernotifikasjon.NotificationOptions
+import no.nav.soknad.innsending.repository.SoknadRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class NotificationService(
+	private val publisher: BrukernotifikasjonPublisher,
+	private val soknadRepository: SoknadRepository,
+) {
+	private val logger = LoggerFactory.getLogger(javaClass)
+
+	fun create(innsendingsId: String, opts: NotificationOptions = NotificationOptions()) {
+		logger.debug("$innsendingsId: Skal opprette brukernotifikasjon")
+		soknadRepository.findByInnsendingsid(innsendingsId)?.let {
+			publisher.createNotification(it, opts)
+		} ?: logSoknadNotFound(innsendingsId)
+	}
+
+	fun close(innsendingsId: String) {
+		logger.debug("$innsendingsId: Skal lukke brukernotifikasjon")
+		soknadRepository.findByInnsendingsid(innsendingsId)?.let {
+			publisher.closeNotification(it)
+		} ?: logSoknadNotFound(innsendingsId)
+	}
+
+	private fun logSoknadNotFound(innsendingsId: String) = logger.warn("$innsendingsId: Fant ikke søknad med gitt innsendingsid")
+
+}

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/service/SoknadService.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/service/SoknadService.kt
@@ -273,7 +273,7 @@ class SoknadService(
 	@Transactional
 	fun deleteSoknadBeforeCutoffDate(
 		cutoffDate: OffsetDateTime
-	) {
+	): List<String> {
 		logger.info("Finner søknader som skal slettes før $cutoffDate")
 
 		val soknaderToDelete =
@@ -285,8 +285,7 @@ class SoknadService(
 			)
 
 		logger.info("Funnet ${soknaderToDelete.size} søknader som skal slettes")
-		soknaderToDelete.forEach { slettSoknadAutomatisk(it.innsendingsid) }
-
+		return soknaderToDelete.map { it.innsendingsid }.onEach { slettSoknadAutomatisk(it) }
 	}
 
 	@Transactional

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/service/SoknadService.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/service/SoknadService.kt
@@ -1,6 +1,5 @@
 package no.nav.soknad.innsending.service
 
-import no.nav.soknad.innsending.brukernotifikasjon.BrukernotifikasjonPublisher
 import no.nav.soknad.innsending.exceptions.BackendErrorException
 import no.nav.soknad.innsending.exceptions.ExceptionHelper
 import no.nav.soknad.innsending.exceptions.IllegalActionException
@@ -33,7 +32,6 @@ class SoknadService(
 	private val repo: RepositoryUtils,
 	private val vedleggService: VedleggService,
 	private val filService: FilService,
-	private val brukernotifikasjonPublisher: BrukernotifikasjonPublisher,
 	private val innsenderMetrics: InnsenderMetrics,
 	private val exceptionHelper: ExceptionHelper,
 	private val subjectHandler: SubjectHandlerInterface
@@ -90,8 +88,6 @@ class SoknadService(
 
 			val dokumentSoknadDto = lagDokumentSoknadDto(savedSoknadDbData, savedVedleggDbDataListe)
 
-			publiserBrukernotifikasjon(dokumentSoknadDto)
-
 			return dokumentSoknadDto
 		} catch (e: Exception) {
 			exceptionHelper.reportException(e, operation, kodeverkSkjema.tema ?: "Ukjent")
@@ -114,7 +110,6 @@ class SoknadService(
 			val savedDokumentSoknadDto = lagDokumentSoknadDto(savedSoknadDbData, savedVedleggDbData)
 			// lagre mottatte filer i fil tabellen.
 			lagreFiler(savedDokumentSoknadDto, dokumentSoknadDto)
-			publiserBrukernotifikasjon(savedDokumentSoknadDto)
 
 			innsenderMetrics.incOperationsCounter(operation, dokumentSoknadDto.tema)
 			return mapTilSkjemaDto(savedDokumentSoknadDto)
@@ -202,15 +197,7 @@ class SoknadService(
 			throw IllegalActionException("Det kan ikke gjøres endring på en slettet eller innsendt søknad. Søknad ${dokumentSoknadDto.innsendingsId} kan ikke slettes da den er innsendt eller slettet")
 
 		dokumentSoknadDto.vedleggsListe.filter { it.id != null }.forEach { vedleggService.slettVedleggOgDensFiler(it) }
-		//fillagerAPI.slettFiler(innsendingsId, dokumentSoknadDto.vedleggsListe)
 		repo.slettSoknad(dokumentSoknadDto, HendelseType.SlettetPermanentAvBruker)
-
-		val soknadDbData =
-			mapTilSoknadDb(dokumentSoknadDto, dokumentSoknadDto.innsendingsId!!, SoknadsStatus.SlettetAvBruker)
-		val slettetSoknad = lagDokumentSoknadDto(
-			soknadDbData,
-			dokumentSoknadDto.vedleggsListe.map { mapTilVedleggDb(it, dokumentSoknadDto.id!!) })
-		publiserBrukernotifikasjon(slettetSoknad)
 		innsenderMetrics.incOperationsCounter(operation, dokumentSoknadDto.tema)
 	}
 
@@ -230,14 +217,9 @@ class SoknadService(
 		if (!dokumentSoknadDto.kanGjoreEndringer)
 			throw IllegalActionException("Det kan ikke gjøres endring på en slettet eller innsendt søknad. Søknad ${dokumentSoknadDto.innsendingsId} kan ikke slettes da den allerede er innsendt")
 
-		//fillagerAPI.slettFiler(innsendingsId, dokumentSoknadDto.vedleggsListe)
 		dokumentSoknadDto.vedleggsListe.filter { it.id != null }.forEach { repo.slettFilerForVedlegg(it.id!!) }
-		val slettetSoknadDb =
-			repo.lagreSoknad(mapTilSoknadDb(dokumentSoknadDto, innsendingsId, SoknadsStatus.AutomatiskSlettet))
+		repo.lagreSoknad(mapTilSoknadDb(dokumentSoknadDto, innsendingsId, SoknadsStatus.AutomatiskSlettet))
 
-		val slettetSoknadDto = lagDokumentSoknadDto(slettetSoknadDb,
-			dokumentSoknadDto.vedleggsListe.map { mapTilVedleggDb(it, dokumentSoknadDto.id!!) })
-		publiserBrukernotifikasjon(slettetSoknadDto)
 		logger.info("slettSoknadAutomatisk: Status for søknad $innsendingsId er satt til ${SoknadsStatus.AutomatiskSlettet}")
 
 		innsenderMetrics.incOperationsCounter(operation, dokumentSoknadDto.tema)
@@ -252,7 +234,6 @@ class SoknadService(
 		repo.slettSoknad(dokumentSoknadDto, HendelseType.SlettetPermanentAvSystem)
 
 		logger.info("$innsendingsId: opprettet:${dokumentSoknadDto.opprettetDato}, status: ${dokumentSoknadDto.status} er permanent slettet")
-
 	}
 
 	@Transactional
@@ -391,13 +372,6 @@ class SoknadService(
 	fun validerInnsendtSoknadMotEksisterende(innsendtSoknad: DokumentSoknadDto, eksisterendeSoknad: DokumentSoknadDto) {
 		innsendtSoknad.validerSoknadVedOppdatering(eksisterendeSoknad)
 		innsendtSoknad.validerVedleggsListeVedOppdatering(eksisterendeSoknad)
-	}
-
-
-	private fun publiserBrukernotifikasjon(dokumentSoknadDto: DokumentSoknadDto): Boolean = try {
-		brukernotifikasjonPublisher.soknadStatusChange(dokumentSoknadDto)
-	} catch (e: Exception) {
-		throw BackendErrorException("Feil i ved avslutning av brukernotifikasjon for søknad ${dokumentSoknadDto.tittel}", e)
 	}
 
 }

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/util/mapping/Date.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/util/mapping/Date.kt
@@ -6,7 +6,7 @@ import java.time.ZoneId
 import kotlin.math.absoluteValue
 
 fun mapTilOffsetDateTime(localDateTime: LocalDateTime?): OffsetDateTime? =
-	if (localDateTime == null) null else localDateTime.atOffset(ZoneId.of("CET").rules.getOffset(localDateTime))
+	localDateTime?.atOffset(ZoneId.of("CET").rules.getOffset(localDateTime))
 
 fun mapTilOffsetDateTime(localDateTime: LocalDateTime, offset: Long): OffsetDateTime {
 	if (offset < 0) {
@@ -18,3 +18,4 @@ fun mapTilOffsetDateTime(localDateTime: LocalDateTime, offset: Long): OffsetDate
 fun mapTilLocalDateTime(offsetDateTime: OffsetDateTime?): LocalDateTime? =
 	offsetDateTime?.toLocalDateTime()
 
+fun LocalDateTime.toOffsetDateTime(): OffsetDateTime = this.atOffset(ZoneId.of("CET").rules.getOffset(this))

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/util/mapping/Soknad.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/util/mapping/Soknad.kt
@@ -8,11 +8,11 @@ import no.nav.soknad.innsending.repository.domain.models.FilDbData
 import no.nav.soknad.innsending.repository.domain.models.SoknadDbData
 import no.nav.soknad.innsending.repository.domain.models.VedleggDbData
 import no.nav.soknad.innsending.util.Constants
-import no.nav.soknad.innsending.util.Skjema.createSkjemaPathFromSkjemanr
 import no.nav.soknad.innsending.util.models.hoveddokument
 import no.nav.soknad.innsending.util.models.hoveddokumentVariant
 import no.nav.soknad.innsending.util.models.sletteDato
 import no.nav.soknad.innsending.util.models.vedleggsListeUtenHoveddokument
+import no.nav.soknad.innsending.util.soknaddbdata.getSkjemaPath
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 
@@ -75,7 +75,7 @@ fun lagDokumentSoknadDto(
 		arkiveringsStatus = mapTilArkiveringsStatusDto(soknadDbData.arkiveringsstatus),
 		erSystemGenerert = erSystemGenerert,
 		soknadstype = if (erEttersending) SoknadType.ettersendelse else SoknadType.soknad,
-		skjemaPath = createSkjemaPathFromSkjemanr(soknadDbData.skjemanr),
+		skjemaPath = soknadDbData.getSkjemaPath(),
 		applikasjon = soknadDbData.applikasjon,
 		skalSlettesDato = soknadDbData.skalslettesdato,
 	)
@@ -119,7 +119,7 @@ fun mapTilDokumentSoknadDto(
 		arkiveringsStatus = mapTilArkiveringsStatusDto(soknadDbData.arkiveringsstatus),
 		erSystemGenerert = false,
 		soknadstype = if (erEttersending) SoknadType.ettersendelse else SoknadType.soknad,
-		skjemaPath = createSkjemaPathFromSkjemanr(soknadDbData.skjemanr),
+		skjemaPath = soknadDbData.getSkjemaPath(),
 		applikasjon = soknadDbData.applikasjon,
 		skalSlettesDato = soknadDbData.skalslettesdato,
 	)

--- a/innsender/src/main/kotlin/no/nav/soknad/innsending/util/soknaddbdata/SoknadDbDataExtensions.kt
+++ b/innsender/src/main/kotlin/no/nav/soknad/innsending/util/soknaddbdata/SoknadDbDataExtensions.kt
@@ -1,0 +1,8 @@
+package no.nav.soknad.innsending.util.soknaddbdata
+
+import no.nav.soknad.innsending.repository.domain.models.SoknadDbData
+import no.nav.soknad.innsending.util.Skjema.createSkjemaPathFromSkjemanr
+
+fun SoknadDbData.isEttersending(): Boolean = ettersendingsid != null
+
+fun SoknadDbData.getSkjemaPath(): String = createSkjemaPathFromSkjemanr(skjemanr)

--- a/innsender/src/main/resources/application.yml
+++ b/innsender/src/main/resources/application.yml
@@ -102,6 +102,9 @@ restconfig:
     urls:
       default: http://localhost:3100/sendinn
   fyllUtUrl: http://localhost:3001/fyllut
+  fyllut:
+    urls:
+      default: http://localhost:3001/fyllut
   clientId: clientId
   clientSecret: clientSecret
   pdlScope: api://dev-fss.pdl.pdl-api/.default
@@ -115,9 +118,6 @@ restconfig:
   kontoregisterUrl: http://localhost:9043/kontoregister-api
 
 brukernotifikasjonconfig:
-  profiles: test
-  fyllutUrl: http://localhost:3001/fyllut
-  sendinnUrl: http://localhost:3100/sendinn
   publisereEndringer: true
 
 ---
@@ -150,6 +150,9 @@ restconfig:
     urls:
       default: http://localhost:3100/sendinn
   fyllUtUrl: http://localhost:3001/fyllut
+  fyllut:
+    urls:
+      default: http://localhost:3001/fyllut
   clientId: ${AZURE_APP_CLIENT_ID}
   clientSecret: ${AZURE_APP_CLIENT_SECRET}
   pdlScope: ${PDL_SCOPE:api://dev-fss.pdl.pdl-api/.default}
@@ -163,8 +166,6 @@ restconfig:
   kontoregisterUrl: ${KONTOREGISTER_URL:http://kontoregister.no}
 
 brukernotifikasjonconfig:
-  fyllutUrl: http://localhost:3001/fyllut
-  sendinnUrl: http://localhost:3100/sendinn
   publisereEndringer: true
 
 kafka:
@@ -224,6 +225,9 @@ restconfig:
     urls:
       default: ${SEND_INN_URL}
   fyllUtUrl: ${FYLL_UT_URL}
+  fyllut:
+    urls:
+      default: ${FYLL_UT_URL}
   clientId: ${AZURE_APP_CLIENT_ID}
   clientSecret: ${AZURE_APP_CLIENT_SECRET}
   pdlScope: ${PDL_SCOPE}
@@ -238,9 +242,6 @@ restconfig:
 
 
 brukernotifikasjonconfig:
-  profiles: ${SPRING_PROFILES_ACTIVE}
-  fyllutUrl: ${FYLL_UT_URL}
-  sendinnUrl: ${SEND_INN_URL}
   publisereEndringer: ${PUBLISERE_BRUKERNOTIFIKASJONER}
 
 ettersendingsfrist: ${ETTERSENDINGSFRIST}
@@ -353,3 +354,11 @@ restconfig:
       preprodAltAnsatt: https://www.ansatt.dev.nav.no/sendinn-alt
       delingslenke: https://www.ansatt.dev.nav.no/sendinn-delingslenke
       default: ${SEND_INN_URL:http://localhost:3100/sendinn}
+  fyllut:
+    urls:
+      preprodIntern: https://fyllut-preprod.intern.dev.nav.no/fyllut
+      preprodAltIntern: https://fyllut-preprod-alt.intern.dev.nav.no/fyllut
+      preprodAnsatt: https://fyllut-preprod.ansatt.dev.nav.no/fyllut
+      preprodAltAnsatt: https://fyllut-preprod-alt.ansatt.dev.nav.no/fyllut
+      delingslenke: https://skjemadelingslenke.ekstern.dev.nav.no/fyllut
+      default: ${FYLL_UT_URL:http://localhost:3001/fyllut}

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/brukernotifikasjon/kafka/SendTilPublisherRetryTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/brukernotifikasjon/kafka/SendTilPublisherRetryTest.kt
@@ -1,84 +1,86 @@
 package no.nav.soknad.innsending.brukernotifikasjon.kafka
 
+import com.ninjasquad.springmockk.SpykBean
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.verify
 import no.nav.soknad.arkivering.soknadsmottaker.model.AddNotification
-import no.nav.soknad.arkivering.soknadsmottaker.model.NotificationInfo
-import no.nav.soknad.arkivering.soknadsmottaker.model.SoknadRef
 import no.nav.soknad.innsending.ApplicationTest
 import no.nav.soknad.innsending.brukernotifikasjon.BrukernotifikasjonPublisher
-import no.nav.soknad.innsending.config.BrukerNotifikasjonConfig
 import no.nav.soknad.innsending.consumerapis.brukernotifikasjonpublisher.PublisherInterface
-import no.nav.soknad.innsending.model.SoknadType
-import no.nav.soknad.innsending.utils.Hjelpemetoder
+import no.nav.soknad.innsending.utils.builders.SoknadDbDataTestBuilder
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.mock.mockito.SpyBean
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class SendTilPublisherRetryTest : ApplicationTest() {
 
-	@Autowired
-	private val notifikasjonConfig: BrukerNotifikasjonConfig = BrukerNotifikasjonConfig()
-
-	@SpyBean
+	@SpykBean
 	private lateinit var sendTilPublisher: PublisherInterface
 
-	private var brukernotifikasjonPublisher: BrukernotifikasjonPublisher? = null
-	private val defaultSkjemanr = "NAV 55-00.60"
-	private val defaultTema = "BID"
-	private val defaultTittel = "Avtale om barnebidrag"
+	@Autowired
+	lateinit var brukernotifikasjonPublisher: BrukernotifikasjonPublisher
 
 	@BeforeEach
-	fun setUp() {
-		brukernotifikasjonPublisher = BrukernotifikasjonPublisher(notifikasjonConfig, sendTilPublisher)
-	}
-
+	fun setUp() = clearAllMocks()
 
 	@Test
-	fun `sjekk at notifikasjonsmelding resendes hvis den feiler`() {
+	fun `attempts to send notification three times before giving up`() {
 		val innsendingsid = "123456"
-		val skjemanr = defaultSkjemanr
-		val tema = defaultTema
-		val spraak = "no"
-		val personId = "12125912345"
-		val tittel = "Dokumentasjon av utdanning"
-		val id = 1L
 
-		val dokumentSoknad = Hjelpemetoder.lagDokumentSoknad(
-			brukerId = personId,
-			skjemanr = skjemanr,
-			spraak = spraak,
-			tittel = tittel,
-			tema = tema,
-			id = id,
-			innsendingsid = innsendingsid,
-			soknadstype = SoknadType.soknad
-		)
+		every { sendTilPublisher.opprettBrukernotifikasjon(any()) } throws RuntimeException("Feil ved sending av brukernotifikasjon")
 
-		val soknadRef = SoknadRef(
-			dokumentSoknad.innsendingsId!!,
-			false,
-			dokumentSoknad.innsendingsId!!,
-			dokumentSoknad.brukerId,
-			dokumentSoknad.opprettetDato,
-			erSystemGenerert = dokumentSoknad.erSystemGenerert ?: false
-		)
+		val soknad = SoknadDbDataTestBuilder(innsendingsId = innsendingsid).build()
+		val notificationCreated = brukernotifikasjonPublisher.createNotification(soknad)
 
-		val brukernotifikasjonInfo = NotificationInfo(
-			notifikasjonsTittel = dokumentSoknad.tittel,
-			lenke = "http://localhost:3001/fyllut/nav550060/oppsummering?sub=digital&innsendingsId=123456",
-			antallAktiveDager = 28,
-			eksternVarsling = emptyList()
-		)
-		val notificationInfo = AddNotification(soknadRef, brukernotifikasjonInfo)
+		val notifications = mutableListOf<AddNotification>()
+		verify(exactly = 3) { sendTilPublisher.opprettBrukernotifikasjon(capture(notifications)) }
 
-		Mockito.doThrow(RuntimeException::class.java).`when`(sendTilPublisher)
-			.opprettBrukernotifikasjon(notificationInfo)
+		assertFalse { notificationCreated }
+		assertEquals(3, notifications.size)
+		assertTrue { notifications.all { it.soknadRef.innsendingId == soknad.innsendingsid } }
+	}
 
-		brukernotifikasjonPublisher?.soknadStatusChange(dokumentSoknad)
+	@Test
+	fun `sends the notification the second time after one failure`() {
+		val innsendingsid = "123456"
 
-		Mockito.verify(sendTilPublisher, Mockito.times(3)).opprettBrukernotifikasjon(notificationInfo)
+		every { sendTilPublisher.opprettBrukernotifikasjon(any()) }
+			.throws(RuntimeException("First failure"))
+			.andThen(Unit)
 
+		val soknad = SoknadDbDataTestBuilder(innsendingsId = innsendingsid).build()
+		val notificationCreated = brukernotifikasjonPublisher.createNotification(soknad)
+
+		val notifications = mutableListOf<AddNotification>()
+		verify(exactly = 2) { sendTilPublisher.opprettBrukernotifikasjon(capture(notifications)) }
+
+		assertTrue { notificationCreated }
+		assertEquals(2, notifications.size)
+		assertTrue { notifications.all { it.soknadRef.innsendingId == soknad.innsendingsid } }
+	}
+
+	@Test
+	fun `sends the notification the third time after two failures`() {
+		val innsendingsid = "123456"
+
+		every { sendTilPublisher.opprettBrukernotifikasjon(any()) }
+			.throws(RuntimeException("First failure"))
+			.andThenThrows(RuntimeException("Second failure"))
+			.andThen(Unit)
+
+		val soknad = SoknadDbDataTestBuilder(innsendingsId = innsendingsid).build()
+		val notificationCreated = brukernotifikasjonPublisher.createNotification(soknad)
+
+		val notifications = mutableListOf<AddNotification>()
+		verify(exactly = 3) { sendTilPublisher.opprettBrukernotifikasjon(capture(notifications)) }
+
+		assertTrue { notificationCreated }
+		assertEquals(3, notifications.size)
+		assertTrue { notifications.all { it.soknadRef.innsendingId == soknad.innsendingsid } }
 	}
 
 }

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/cleanup/SlettArkiverteSoknaderTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/cleanup/SlettArkiverteSoknaderTest.kt
@@ -3,13 +3,11 @@ package no.nav.soknad.innsending.cleanup
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import no.nav.soknad.innsending.ApplicationTest
-import no.nav.soknad.innsending.brukernotifikasjon.BrukernotifikasjonPublisher
 import no.nav.soknad.innsending.consumerapis.pdl.PdlAPI
 import no.nav.soknad.innsending.consumerapis.pdl.dto.IdentDto
 import no.nav.soknad.innsending.consumerapis.pdl.dto.PersonDto
 import no.nav.soknad.innsending.consumerapis.soknadsmottaker.MottakerAPITest
 import no.nav.soknad.innsending.exceptions.ResourceNotFoundException
-import no.nav.soknad.innsending.model.DokumentSoknadDto
 import no.nav.soknad.innsending.model.SoknadsStatusDto
 import no.nav.soknad.innsending.repository.domain.enums.ArkiveringsStatus
 import no.nav.soknad.innsending.security.SubjectHandlerInterface
@@ -45,9 +43,6 @@ class SlettArkiverteSoknaderTest : ApplicationTest() {
 	private lateinit var innsendingService: InnsendingService
 
 	@MockkBean
-	private lateinit var brukernotifikasjonPublisher: BrukernotifikasjonPublisher
-
-	@MockkBean
 	private lateinit var leaderSelectionUtility: LeaderSelectionUtility
 
 	@MockkBean
@@ -65,8 +60,6 @@ class SlettArkiverteSoknaderTest : ApplicationTest() {
 	fun testSlettingAvInnsendteSoknader() {
 		SlettArkiverteSoknader(leaderSelectionUtility, soknadService)
 
-		val soknader = mutableListOf<DokumentSoknadDto>()
-		every { brukernotifikasjonPublisher.soknadStatusChange(capture(soknader)) } returns true
 		every { leaderSelectionUtility.isLeader() } returns true
 		every { soknadsmottakerAPI.sendInnSoknad(any(), any()) } returns Unit
 		every { pdlInterface.hentPersonIdents(any()) } returns listOf(IdentDto("123456789", "FOLKEREGISTERIDENT", false))

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/rest/ettersending/EttersendingRestApiTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/rest/ettersending/EttersendingRestApiTest.kt
@@ -1,13 +1,22 @@
 package no.nav.soknad.innsending.rest.ettersending
 
+import com.ninjasquad.springmockk.SpykBean
+import io.mockk.clearAllMocks
+import io.mockk.slot
+import io.mockk.verify
 import no.nav.security.mock.oauth2.MockOAuth2Server
+import no.nav.soknad.arkivering.soknadsmottaker.model.AddNotification
+import no.nav.soknad.arkivering.soknadsmottaker.model.Varsel
 import no.nav.soknad.innsending.ApplicationTest
+import no.nav.soknad.innsending.consumerapis.brukernotifikasjonpublisher.PublisherInterface
 import no.nav.soknad.innsending.utils.Api
 import no.nav.soknad.innsending.utils.builders.SkjemaDtoTestBuilder
 import no.nav.soknad.innsending.utils.builders.ettersending.InnsendtVedleggDtoTestBuilder
 import no.nav.soknad.innsending.utils.builders.ettersending.OpprettEttersendingTestBuilder
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -22,6 +31,9 @@ class EttersendingRestApiTest : ApplicationTest() {
 	@Autowired
 	lateinit var restTemplate: TestRestTemplate
 
+	@SpykBean
+	lateinit var notificationPublisher: PublisherInterface
+
 	@Value("\${server.port}")
 	var serverPort: Int? = 9064
 
@@ -30,6 +42,7 @@ class EttersendingRestApiTest : ApplicationTest() {
 	@BeforeEach
 	fun setup() {
 		api = Api(restTemplate, serverPort!!, mockOAuth2Server)
+		clearAllMocks()
 	}
 
 	@Test
@@ -39,23 +52,38 @@ class EttersendingRestApiTest : ApplicationTest() {
 		val tema = "DAG"
 		val vedleggsnr = "A1"
 
-		val ettersending = OpprettEttersendingTestBuilder()
+		val opprettEttersendingRequest = OpprettEttersendingTestBuilder()
 			.skjemanr(skjemanr)
 			.tema(tema)
 			.vedleggsListe(listOf(InnsendtVedleggDtoTestBuilder().vedleggsnr(vedleggsnr).build()))
 			.build()
 
 		// When
-		val response = api?.createEttersending(ettersending)
+		val ettersending = api!!.createEttersending(opprettEttersendingRequest)
+			.assertSuccess()
+			.body
 
 		// Then
-		assertNotNull(response?.body)
+		assertEquals(skjemanr, ettersending.skjemanr)
+		assertEquals(tema, ettersending.tema)
+		assertEquals(1, ettersending.vedleggsListe.size)
+		assertEquals(vedleggsnr, ettersending.vedleggsListe[0].vedleggsnr)
 
-		val body = response!!.body!!
-		assertEquals(skjemanr, body.skjemanr)
-		assertEquals(tema, body.tema)
-		assertEquals(1, body.vedleggsListe.size)
-		assertEquals(vedleggsnr, body.vedleggsListe[0].vedleggsnr)
+		val notificationSlot = slot<AddNotification>()
+		verify(exactly = 1) { notificationPublisher.opprettBrukernotifikasjon(capture(notificationSlot)) }
+		val notification = notificationSlot.captured
+
+		assertEquals(ettersending.innsendingsId, notification.soknadRef.innsendingId)
+		assertEquals(ettersending.innsendingsId, notification.soknadRef.groupId)
+		assertEquals(ettersending.brukerId, notification.soknadRef.personId)
+		assertEquals(false, notification.soknadRef.erSystemGenerert)
+		assertEquals(true, notification.soknadRef.erEttersendelse)
+		assertEquals("Ettersend manglende vedlegg til: ${ettersending.tittel}", notification.brukernotifikasjonInfo.notifikasjonsTittel)
+		assertEquals(28, notification.brukernotifikasjonInfo.antallAktiveDager)
+		assertNotNull(notification.brukernotifikasjonInfo.lenke)
+		assertEquals(1, notification.brukernotifikasjonInfo.eksternVarsling.size)
+		assertTrue(notification.brukernotifikasjonInfo.eksternVarsling.any { it.kanal === Varsel.Kanal.sms })
+		assertNull(notification.brukernotifikasjonInfo.utsettSendingTil)
 	}
 
 	@Test
@@ -64,11 +92,14 @@ class EttersendingRestApiTest : ApplicationTest() {
 		val vedleggsnr = "A1"
 		val skjemaDto = SkjemaDtoTestBuilder().build()
 
-		val opprettetSoknadResponse = api?.createSoknad(skjemaDto)
-		val innsendingsId = opprettetSoknadResponse?.body?.innsendingsId!!
+		val opprettetSoknad = api!!.createSoknad(skjemaDto)
+			.assertSuccess()
+			.body
+		val innsendingsId = opprettetSoknad.innsendingsId!!
 
 		api?.utfyltSoknad(innsendingsId, skjemaDto)
-		api?.sendInnSoknad(innsendingsId)
+		val sendInnSoknadResponse = api?.sendInnSoknad(innsendingsId)
+		val innsendtSoknad = sendInnSoknadResponse!!.body!!
 
 		val ettersending = OpprettEttersendingTestBuilder()
 			.skjemanr(skjemaDto.skjemanr)
@@ -76,15 +107,30 @@ class EttersendingRestApiTest : ApplicationTest() {
 			.build()
 
 		// When
-		val response = api?.createEttersending(ettersending)
+		val manueltOpprettetEttersending = api!!.createEttersending(ettersending)
+			.assertSuccess()
+			.body
 
 		// Then
-		assertNotNull(response?.body)
+		assertEquals(1, manueltOpprettetEttersending.vedleggsListe.size)
+		assertEquals(innsendingsId, manueltOpprettetEttersending.ettersendingsId, "Should have ettersendingId from existing søknad innsendingsId")
+		assertEquals(vedleggsnr, manueltOpprettetEttersending.vedleggsListe[0].vedleggsnr)
 
-		val body = response!!.body!!
-		assertEquals(1, body.vedleggsListe.size)
-		assertEquals(innsendingsId, body.ettersendingsId, "Should have ettersendingId from existing søknad innsendingsId")
-		assertEquals(vedleggsnr, body.vedleggsListe[0].vedleggsnr)
+		val notifications = mutableListOf<AddNotification>()
+		verify(exactly = 2) { notificationPublisher.opprettBrukernotifikasjon(capture(notifications)) }
+		val lastNotification = notifications.last()
+
+		assertEquals(manueltOpprettetEttersending.innsendingsId, lastNotification.soknadRef.innsendingId)
+		assertEquals(innsendtSoknad.innsendingsId, lastNotification.soknadRef.groupId)
+		assertEquals(manueltOpprettetEttersending.brukerId, lastNotification.soknadRef.personId)
+		assertEquals(false, lastNotification.soknadRef.erSystemGenerert)
+		assertEquals(true, lastNotification.soknadRef.erEttersendelse)
+		assertEquals("Ettersend manglende vedlegg til: ${ettersending.tittel}", lastNotification.brukernotifikasjonInfo.notifikasjonsTittel)
+		assertEquals(28, lastNotification.brukernotifikasjonInfo.antallAktiveDager)
+		assertNotNull(lastNotification.brukernotifikasjonInfo.lenke)
+		assertEquals(1, lastNotification.brukernotifikasjonInfo.eksternVarsling.size)
+		assertTrue(lastNotification.brukernotifikasjonInfo.eksternVarsling.any { it.kanal === Varsel.Kanal.sms })
+		assertNull(lastNotification.brukernotifikasjonInfo.utsettSendingTil)
 	}
 
 }

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/rest/fyllut/FyllutRestApiTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/rest/fyllut/FyllutRestApiTest.kt
@@ -1,11 +1,17 @@
 package no.nav.soknad.innsending.rest.fyllut
 
 import com.ninjasquad.springmockk.MockkBean
+import com.ninjasquad.springmockk.SpykBean
+import io.mockk.clearAllMocks
 import io.mockk.every
+import io.mockk.slot
+import io.mockk.verify
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenResponse
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
+import no.nav.soknad.arkivering.soknadsmottaker.model.AddNotification
 import no.nav.soknad.innsending.ApplicationTest
+import no.nav.soknad.innsending.consumerapis.brukernotifikasjonpublisher.PublisherInterface
 import no.nav.soknad.innsending.exceptions.ErrorCode
 import no.nav.soknad.innsending.exceptions.ResourceNotFoundException
 import no.nav.soknad.innsending.model.*
@@ -45,6 +51,9 @@ class FyllutRestApiTest : ApplicationTest() {
 	@MockkBean
 	lateinit var kodeverkService: KodeverkService
 
+	@SpykBean
+	lateinit var notificationPublisher: PublisherInterface
+
 	@Autowired
 	lateinit var restTemplate: TestRestTemplate
 
@@ -71,6 +80,7 @@ class FyllutRestApiTest : ApplicationTest() {
 
 	@BeforeEach
 	fun setup() {
+		clearAllMocks()
 		api = Api(restTemplate, serverPort!!, mockOAuth2Server)
 		every { oauth2TokenService.getAccessToken(any()) } returns OAuth2AccessTokenResponse(access_token = "token")
 		every { kodeverkService.getPoststed(any()) } answers { postnummerMap[firstArg()] }
@@ -91,13 +101,60 @@ class FyllutRestApiTest : ApplicationTest() {
 		val skjemaDto = SkjemaDtoTestBuilder(vedleggsListe = listOf(t7Vedlegg, n6Vedlegg)).build()
 
 		// Når
-		val opprettetSoknadResponse = api?.createSoknad(skjemaDto)
+		val opprettetSoknadResponse = api!!.createSoknad(skjemaDto)
+			.assertSuccess()
 
 		// Så
-		assertTrue(opprettetSoknadResponse != null)
-		assertEquals(201, opprettetSoknadResponse.statusCode.value())
-		testHentSoknadOgSendInn(opprettetSoknadResponse, token)
+		testHentSoknadOgSendInn(opprettetSoknadResponse.body, token)
+	}
 
+	@Test
+	fun testUserNotificationOnSoknadCreation() {
+		// Gitt
+		val vedlegg = SkjemaDokumentDtoTestBuilder(vedleggsnr = "T7").build()
+		val skjemaDto = SkjemaDtoTestBuilder(vedleggsListe = listOf(vedlegg)).build()
+
+		// Når
+		val responseBody = api!!.createSoknad(skjemaDto)
+			.assertSuccess()
+			.body
+
+		// Så
+		val parameterSlot = slot<AddNotification>()
+		verify(exactly = 1) { notificationPublisher.opprettBrukernotifikasjon(capture(parameterSlot)) }
+		val notification = parameterSlot.captured
+
+		assertEquals(responseBody.innsendingsId, notification.soknadRef.innsendingId)
+		assertEquals(responseBody.innsendingsId, notification.soknadRef.groupId)
+		assertEquals(responseBody.brukerId, notification.soknadRef.personId)
+		assertEquals(false, notification.soknadRef.erSystemGenerert)
+		assertEquals(false, notification.soknadRef.erEttersendelse)
+		assertEquals(responseBody.tittel, notification.brukernotifikasjonInfo.notifikasjonsTittel)
+		assertEquals(28, notification.brukernotifikasjonInfo.antallAktiveDager)
+		assertTrue(notification.brukernotifikasjonInfo.lenke.contains("/oppsummering?"), "Unexpected link: ${notification.brukernotifikasjonInfo.lenke}")
+		assertEquals(0, notification.brukernotifikasjonInfo.eksternVarsling.size)
+		assertNull(notification.brukernotifikasjonInfo.utsettSendingTil)
+	}
+
+	@Test
+	fun testUserNotificationWithShorterMellomlagringOnSoknadCreation() {
+		// Gitt
+		val mellomlagringDager = 10
+		val vedlegg = SkjemaDokumentDtoTestBuilder(vedleggsnr = "T7").build()
+		val skjemaDto = SkjemaDtoTestBuilder(vedleggsListe = listOf(vedlegg), mellomlagringDager = mellomlagringDager, skalslettesdato = null).build()
+
+		// Når
+		val responseBody = api!!.createSoknad(skjemaDto)
+			.assertSuccess()
+			.body
+
+		// Så
+		val parameterSlot = slot<AddNotification>()
+		verify(exactly = 1) { notificationPublisher.opprettBrukernotifikasjon(capture(parameterSlot)) }
+		val notification = parameterSlot.captured
+
+		assertEquals(responseBody.innsendingsId, notification.soknadRef.innsendingId)
+		assertEquals(mellomlagringDager, notification.brukernotifikasjonInfo.antallAktiveDager)
 	}
 
 	@Test
@@ -122,12 +179,12 @@ class FyllutRestApiTest : ApplicationTest() {
 	}
 
 	private fun testHentSoknadOgSendInn(
-		response: ResponseEntity<SkjemaDto>,
+		skjema: SkjemaDto,
 		token: String
 	) {
 
 		// Hent søknaden opprettet fra FyllUt og kjør gjennom løp for opplasting av vedlegg og innsending av søknad
-		val innsendingsId = response.body!!.innsendingsId
+		val innsendingsId = skjema.innsendingsId
 		assertNotNull(innsendingsId)
 
 		val getRequestEntity = HttpEntity<Unit>(Hjelpemetoder.createHeaders(token))
@@ -631,12 +688,11 @@ class FyllutRestApiTest : ApplicationTest() {
 		val fraFyllUt = SkjemaDtoTestBuilder(skjemanr = dokumentSoknadDto.skjemanr).build()
 
 		// Når
-		val response = api?.createSoknad(fraFyllUt, true)
+		val response = api!!.createSoknad(fraFyllUt, true)
+			.assertSuccess()
 
 		// Så
-		assertTrue(response != null)
-		assertEquals(201, response.statusCode.value())
-		assertNotEquals(response.body?.innsendingsId, innsendingsId, "Forventer ny innsendingsId")
+		assertNotEquals(response.body.innsendingsId, innsendingsId, "Forventer ny innsendingsId")
 	}
 
 	@Test
@@ -719,17 +775,13 @@ class FyllutRestApiTest : ApplicationTest() {
 		val n6Vedlegg = SkjemaDokumentDtoTestBuilder(vedleggsnr = "N6").build()
 
 		val noOfRepeats: Int = 100
-		val soknader = mutableListOf<ResponseEntity<SkjemaDto>>()
+		val soknader = mutableListOf<SkjemaDto>()
 		repeat(noOfRepeats, {
 			val soknad = SkjemaDtoTestBuilder(vedleggsListe = listOf(t7Vedlegg, n6Vedlegg)).build()
 
 			// Når
-			val opprettetSoknadResponse = api?.createSoknad(soknad)
-
-			assertTrue(opprettetSoknadResponse != null)
-			assertEquals(201, opprettetSoknadResponse.statusCode.value())
-
-			soknader.add(opprettetSoknadResponse)
+			val opprettetSoknadResponse = api!!.createSoknad(soknad).assertSuccess()
+			soknader.add(opprettetSoknadResponse.body)
 
 		})
 

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/rest/fyllut/FyllutRestApiTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/rest/fyllut/FyllutRestApiTest.kt
@@ -115,7 +115,7 @@ class FyllutRestApiTest : ApplicationTest() {
 		val skjemaDto = SkjemaDtoTestBuilder(vedleggsListe = listOf(vedlegg)).build()
 
 		// Når
-		val responseBody = api!!.createSoknad(skjemaDto)
+		val responseBody = api!!.createSoknad(skjemaDto, envQualifier = EnvQualifier.preprodAltAnsatt)
 			.assertSuccess()
 			.body
 
@@ -131,7 +131,14 @@ class FyllutRestApiTest : ApplicationTest() {
 		assertEquals(false, notification.soknadRef.erEttersendelse)
 		assertEquals(responseBody.tittel, notification.brukernotifikasjonInfo.notifikasjonsTittel)
 		assertEquals(28, notification.brukernotifikasjonInfo.antallAktiveDager)
-		assertTrue(notification.brukernotifikasjonInfo.lenke.contains("/oppsummering?"), "Unexpected link: ${notification.brukernotifikasjonInfo.lenke}")
+		assertTrue(
+			notification.brukernotifikasjonInfo.lenke.contains("/oppsummering?"),
+			"Link should point to summary page: ${notification.brukernotifikasjonInfo.lenke}"
+		)
+		assertTrue(
+			notification.brukernotifikasjonInfo.lenke.contains("fyllut-preprod-alt.ansatt.dev.nav.no"),
+			"Incorrect domain in link: ${notification.brukernotifikasjonInfo.lenke}"
+		)
 		assertEquals(0, notification.brukernotifikasjonInfo.eksternVarsling.size)
 		assertNull(notification.brukernotifikasjonInfo.utsettSendingTil)
 	}

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/rest/lospost/LospostRestApiTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/rest/lospost/LospostRestApiTest.kt
@@ -1,7 +1,13 @@
 package no.nav.soknad.innsending.rest.lospost
 
+import com.ninjasquad.springmockk.SpykBean
+import io.mockk.clearAllMocks
+import io.mockk.slot
+import io.mockk.verify
 import no.nav.security.mock.oauth2.MockOAuth2Server
+import no.nav.soknad.arkivering.soknadsmottaker.model.AddNotification
 import no.nav.soknad.innsending.ApplicationTest
+import no.nav.soknad.innsending.consumerapis.brukernotifikasjonpublisher.PublisherInterface
 import no.nav.soknad.innsending.exceptions.ErrorCode
 import no.nav.soknad.innsending.model.EnvQualifier
 import no.nav.soknad.innsending.model.OpplastingsStatusDto
@@ -9,6 +15,8 @@ import no.nav.soknad.innsending.model.OpprettLospost
 import no.nav.soknad.innsending.model.PostVedleggDto
 import no.nav.soknad.innsending.utils.Api
 import no.nav.soknad.innsending.utils.Hjelpemetoder
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -26,14 +34,20 @@ class LospostRestApiTest : ApplicationTest() {
 	@Autowired
 	lateinit var restTemplate: TestRestTemplate
 
+	@SpykBean
+	lateinit var notificationPublisher: PublisherInterface
+
 	@Value("\${server.port}")
 	var serverPort: Int? = 9064
 
-	var api: Api? = null
+	var testApi: Api? = null
+	val api: Api
+		get() = testApi!!
 
 	@BeforeEach
 	fun setup() {
-		api = Api(restTemplate, serverPort!!, mockOAuth2Server)
+		testApi = Api(restTemplate, serverPort!!, mockOAuth2Server)
+		clearAllMocks()
 	}
 
 	@Test
@@ -44,16 +58,16 @@ class LospostRestApiTest : ApplicationTest() {
 			dokumentTittel = "Førerkort",
 			sprak = "nb"
 		)
-		val response = api?.createLospost(request)
-		assertNotNull(response?.body)
+		val response = api.createLospost(request)
+			.assertSuccess()
 
-		val body = response.body!!
+		val body = response.body
 		assertEquals(request.soknadTittel, body.tittel)
 		assertEquals(request.tema, body.tema)
 		assertEquals(request.sprak, body.spraak)
 		assertEquals(1, body.vedleggsListe?.size)
 
-		val vedlegg = response.body?.vedleggsListe?.first()!!
+		val vedlegg = body.vedleggsListe?.first()!!
 		assertEquals("N6", vedlegg.vedleggsnr)
 		assertEquals(request.dokumentTittel, vedlegg.tittel)
 		assertEquals(OpplastingsStatusDto.IkkeValgt, vedlegg.opplastingsStatus)
@@ -67,18 +81,18 @@ class LospostRestApiTest : ApplicationTest() {
 			dokumentTittel = "Førerkort",
 			sprak = "nb"
 		)
-		val createResponse = api?.createLospost(request)
-		assertNotNull(createResponse?.body)
+		val createResponse = api.createLospost(request)
+			.assertSuccess()
 
-		val body = createResponse.body!!
+		val body = createResponse.body
 		assertEquals(1, body.vedleggsListe?.size)
 
-		val vedlegg = createResponse.body?.vedleggsListe?.first()!!
+		val vedlegg = body.vedleggsListe?.first()!!
 		assertEquals("N6", vedlegg.vedleggsnr)
 		assertEquals(request.dokumentTittel, vedlegg.tittel)
 		assertEquals(OpplastingsStatusDto.IkkeValgt, vedlegg.opplastingsStatus)
 		val file35MB = loadFile35MB()
-		api!!.uploadFile(body.innsendingsId!!, vedlegg.id!!, file35MB)
+		api.uploadFile(body.innsendingsId!!, vedlegg.id!!, file35MB)
 			.assertClientError()
 			.assertErrorCode(ErrorCode.VEDLEGG_FILE_SIZE_SUM_TOO_LARGE)
 	}
@@ -91,20 +105,20 @@ class LospostRestApiTest : ApplicationTest() {
 			dokumentTittel = "Førerkort",
 			sprak = "nb"
 		)
-		val createResponse = api?.createLospost(request)
-		assertNotNull(createResponse?.body)
+		val createResponse = api.createLospost(request)
+			.assertSuccess()
 
-		val body = createResponse.body!!
+		val body = createResponse.body
 		assertEquals(1, body.vedleggsListe?.size)
 
-		val vedlegg = createResponse.body?.vedleggsListe?.first()!!
+		val vedlegg = body.vedleggsListe?.first()!!
 		assertEquals("N6", vedlegg.vedleggsnr)
 		assertEquals(request.dokumentTittel, vedlegg.tittel)
 		assertEquals(OpplastingsStatusDto.IkkeValgt, vedlegg.opplastingsStatus)
 		val file10MB = loadFile10MB()
-		api!!.uploadFile(body.innsendingsId!!, vedlegg.id!!, file10MB)
+		api.uploadFile(body.innsendingsId!!, vedlegg.id!!, file10MB)
 			.assertSuccess()
-		api!!.uploadFile(body.innsendingsId!!, vedlegg.id!!, file10MB)
+		api.uploadFile(body.innsendingsId!!, vedlegg.id!!, file10MB)
 			.assertClientError()
 			.assertErrorCode(ErrorCode.VEDLEGG_FILE_SIZE_SUM_TOO_LARGE)
 	}
@@ -117,43 +131,43 @@ class LospostRestApiTest : ApplicationTest() {
 			dokumentTittel = "Førerkort",
 			sprak = "nb"
 		)
-		val createResponse = api?.createLospost(request)
-		assertNotNull(createResponse?.body)
+		val createResponse = api.createLospost(request)
+			.assertSuccess()
 
-		val body = createResponse.body!!
+		val body = createResponse.body
 		assertEquals(1, body.vedleggsListe?.size)
 		val innsendingsId = body.innsendingsId!!
 
-		val vedleggMain = createResponse.body?.vedleggsListe?.first()!!
+		val vedleggMain = body.vedleggsListe?.first()!!
 		assertEquals("N6", vedleggMain.vedleggsnr)
 		assertEquals(request.dokumentTittel, vedleggMain.tittel)
 		assertEquals(OpplastingsStatusDto.IkkeValgt, vedleggMain.opplastingsStatus)
 		val file14MB = loadFile14MB()
-		api!!.uploadFile(innsendingsId, vedleggMain.id!!, file14MB)
+		api.uploadFile(innsendingsId, vedleggMain.id!!, file14MB)
 			.assertSuccess()
 
-		val vedlegg2 = api!!.addVedlegg(innsendingsId, PostVedleggDto("Mer informasjon"))
+		val vedlegg2 = api.addVedlegg(innsendingsId, PostVedleggDto("Mer informasjon"))
 			.assertSuccess()
 			.body
-		api!!.uploadFile(innsendingsId, vedlegg2.id!!, file14MB)
+		api.uploadFile(innsendingsId, vedlegg2.id!!, file14MB)
 			.assertSuccess()
 
-		val vedlegg3 = api!!.addVedlegg(innsendingsId, PostVedleggDto("Litt mer informasjon"))
+		val vedlegg3 = api.addVedlegg(innsendingsId, PostVedleggDto("Litt mer informasjon"))
 			.assertSuccess()
 			.body
-		api!!.uploadFile(innsendingsId, vedlegg3.id!!, file14MB)
+		api.uploadFile(innsendingsId, vedlegg3.id!!, file14MB)
 			.assertSuccess()
 
-		val vedlegg4 = api!!.addVedlegg(innsendingsId, PostVedleggDto("Enda mer informasjon"))
+		val vedlegg4 = api.addVedlegg(innsendingsId, PostVedleggDto("Enda mer informasjon"))
 			.assertSuccess()
 			.body
-		api!!.uploadFile(innsendingsId, vedlegg4.id!!, file14MB)
+		api.uploadFile(innsendingsId, vedlegg4.id!!, file14MB)
 			.assertClientError()
 			.assertErrorCode(ErrorCode.FILE_SIZE_SUM_TOO_LARGE)
 	}
 
 	@Test
-	fun `Should return location based on env qualifier`() {
+	fun `Should resolve urls based on env qualifier ansatt`() {
 		val request = OpprettLospost(
 			soknadTittel = "PEN - Arbeidskontrakt",
 			tema = "PEN",
@@ -161,11 +175,69 @@ class LospostRestApiTest : ApplicationTest() {
 			sprak = "nb"
 		)
 
-		val responseAnsatt = api?.createLospost(request, EnvQualifier.preprodAnsatt)
-		assertContains(responseAnsatt?.headers?.location.toString(), "ansatt.dev.nav.no")
+		val response = api.createLospost(request, EnvQualifier.preprodAnsatt)
+			.assertSuccess()
+		assertContains(response.headers?.location.toString(), "ansatt.dev.nav.no/sendinn")
 
-		val responseIntern = api?.createLospost(request, EnvQualifier.preprodIntern)
-		assertContains(responseIntern?.headers?.location.toString(), "intern.dev.nav.no")
+		val parameterSlot = slot<AddNotification>()
+		verify(exactly = 1) { notificationPublisher.opprettBrukernotifikasjon(capture(parameterSlot)) }
+		val notification = parameterSlot.captured
+		assertTrue(
+			notification.brukernotifikasjonInfo.lenke.contains("ansatt.dev.nav.no/sendinn"),
+			"Link not expected: ${notification.brukernotifikasjonInfo.lenke}"
+		)
+	}
+
+	@Test
+	fun `Should resolve urls based on env qualifier intern`() {
+		val request = OpprettLospost(
+			soknadTittel = "PEN - Arbeidskontrakt",
+			tema = "PEN",
+			dokumentTittel = "Arbeidskontrakt",
+			sprak = "nb"
+		)
+
+		val response = api.createLospost(request, EnvQualifier.preprodIntern)
+			.assertSuccess()
+		assertContains(response.headers?.location.toString(), "intern.dev.nav.no/sendinn")
+
+		val parameter = slot<AddNotification>()
+		verify(exactly = 1) { notificationPublisher.opprettBrukernotifikasjon(capture(parameter)) }
+		val notification = parameter.captured
+		assertTrue(
+			notification.brukernotifikasjonInfo.lenke.contains("intern.dev.nav.no/sendinn"),
+			"Link not expected: ${notification.brukernotifikasjonInfo.lenke}"
+		)
+	}
+
+	@Test
+	fun `Should create notification with correct information`() {
+		val request = OpprettLospost(
+			soknadTittel = "PEN - Arbeidskontrakt",
+			tema = "PEN",
+			dokumentTittel = "Arbeidskontrakt",
+			sprak = "nb"
+		)
+
+		val lospostDto = api.createLospost(request)
+			.assertSuccess()
+			.body
+		assertNotNull(lospostDto.innsendingsId)
+
+		val parameterSlot = slot<AddNotification>()
+		verify(exactly = 1) { notificationPublisher.opprettBrukernotifikasjon(capture(parameterSlot)) }
+		val notification = parameterSlot.captured
+
+		assertEquals(lospostDto.innsendingsId, notification.soknadRef.innsendingId)
+		assertEquals(lospostDto.innsendingsId, notification.soknadRef.groupId)
+		assertEquals(lospostDto.brukerId, notification.soknadRef.personId)
+		assertEquals(false, notification.soknadRef.erSystemGenerert)
+		assertEquals(false, notification.soknadRef.erEttersendelse)
+		assertEquals(lospostDto.tittel, notification.brukernotifikasjonInfo.notifikasjonsTittel)
+		assertEquals(1, notification.brukernotifikasjonInfo.antallAktiveDager)
+		assertNotNull(notification.brukernotifikasjonInfo.lenke)
+		assertEquals(0, notification.brukernotifikasjonInfo.eksternVarsling.size)
+		assertNull(notification.brukernotifikasjonInfo.utsettSendingTil)
 	}
 
 	fun loadFile10MB() = Hjelpemetoder.getBytesFromFile("/mellomstor-fra-jpg.pdf")

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/rest/sendinn/SoknadRestApiTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/rest/sendinn/SoknadRestApiTest.kt
@@ -1,13 +1,24 @@
 package no.nav.soknad.innsending.rest.sendinn
 
+import com.ninjasquad.springmockk.SpykBean
+import io.mockk.clearAllMocks
+import io.mockk.verify
 import no.nav.security.mock.oauth2.MockOAuth2Server
+import no.nav.soknad.arkivering.soknadsmottaker.model.AddNotification
 import no.nav.soknad.innsending.ApplicationTest
+import no.nav.soknad.innsending.consumerapis.brukernotifikasjonpublisher.PublisherInterface
 import no.nav.soknad.innsending.model.SoknadType
 import no.nav.soknad.innsending.service.SoknadService
 import no.nav.soknad.innsending.utils.Api
+import no.nav.soknad.innsending.utils.Hjelpemetoder
 import no.nav.soknad.innsending.utils.TokenGenerator
 import no.nav.soknad.innsending.utils.builders.DokumentSoknadDtoTestBuilder
+import no.nav.soknad.innsending.utils.builders.SkjemaDokumentDtoTestBuilder
+import no.nav.soknad.innsending.utils.builders.SkjemaDtoTestBuilder
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -18,6 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.http.HttpStatus
+import kotlin.test.assertNotEquals
 
 class SoknadRestApiTest : ApplicationTest() {
 	@Autowired
@@ -28,6 +40,9 @@ class SoknadRestApiTest : ApplicationTest() {
 
 	@Autowired
 	lateinit var soknadService: SoknadService
+
+	@SpykBean
+	lateinit var notificationPublisher: PublisherInterface
 
 	@Value("\${server.port}")
 	var serverPort: Int? = 9064
@@ -40,6 +55,7 @@ class SoknadRestApiTest : ApplicationTest() {
 	@BeforeEach
 	fun setup() {
 		api = Api(restTemplate, serverPort!!, mockOAuth2Server)
+		clearAllMocks()
 	}
 
 	@Test
@@ -64,7 +80,7 @@ class SoknadRestApiTest : ApplicationTest() {
 		assertTrue(postResponse?.body != null)
 		assertTrue(getResponse?.body != null)
 		assertEquals(postResponse?.body?.innsendingsId, getSoknadDto!!.innsendingsId)
-		assertEquals("application", getResponse.body?.applikasjon)
+		assertEquals("application", getResponse.body.applikasjon)
 	}
 
 	companion object {
@@ -112,6 +128,45 @@ class SoknadRestApiTest : ApplicationTest() {
 		assertEquals(expectedTotalSize, response.body!!.size)
 		assertEquals(expectedEttersendingSize, responseEttersending.size)
 		assertEquals(expectedSoknadSize, responseSoknad.size)
+	}
+
+	@Test
+	fun `Should create notification when ettersending is automatically created due to missing attachments`() {
+		val createSoknadRequest = SkjemaDtoTestBuilder(vedleggsListe = listOf(
+			SkjemaDokumentDtoTestBuilder(vedleggsnr = "T7").build(),
+			SkjemaDokumentDtoTestBuilder(vedleggsnr = "N6").build()
+		)).build()
+		val innsendingsId = api!!.createSoknad(createSoknadRequest)
+			.assertSuccess().body.innsendingsId!!
+		val soknad = api!!.getSoknadSendinn(innsendingsId)
+			.assertSuccess().body
+
+		val vedleggsId = soknad.vedleggsListe.first { it.vedleggsnr == "N6" }.id
+		val fil = Hjelpemetoder.getBytesFromFile("/litenPdf.pdf")
+		api!!.uploadFile(innsendingsId, vedleggsId!!, fil)
+
+		val innsendingskvittering = api!!.sendInnSoknad(innsendingsId)
+			.assertSuccess().body
+		assertEquals(1, innsendingskvittering.skalEttersendes?.size)
+
+		val notifications = mutableListOf<AddNotification>()
+		verify(exactly = 2) { notificationPublisher.opprettBrukernotifikasjon(capture(notifications)) }
+		verify(exactly = 1) { notificationPublisher.avsluttBrukernotifikasjon(any()) }
+
+		val notificationForInitialSoknad = notifications.first()
+		assertFalse(notificationForInitialSoknad.soknadRef.erEttersendelse)
+		assertEquals(false, notificationForInitialSoknad.soknadRef.erSystemGenerert)
+		assertEquals(innsendingsId, notificationForInitialSoknad.soknadRef.innsendingId)
+		assertEquals(innsendingsId, notificationForInitialSoknad.soknadRef.groupId)
+		assertNull(notificationForInitialSoknad.brukernotifikasjonInfo.utsettSendingTil)
+
+		val notificationForEttersending = notifications.last()
+		assertTrue(notificationForEttersending.soknadRef.erEttersendelse)
+		assertEquals(true, notificationForEttersending.soknadRef.erSystemGenerert)
+		assertNotNull(notificationForEttersending.soknadRef.innsendingId)
+		assertNotEquals(innsendingsId, notificationForEttersending.soknadRef.innsendingId)
+		assertEquals(innsendingsId, notificationForEttersending.soknadRef.groupId)
+		assertNotNull(notificationForEttersending.brukernotifikasjonInfo.utsettSendingTil)
 	}
 
 }

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/service/InnsendingServiceTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/service/InnsendingServiceTest.kt
@@ -4,7 +4,6 @@ import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.soknad.innsending.ApplicationTest
-import no.nav.soknad.innsending.brukernotifikasjon.BrukernotifikasjonPublisher
 import no.nav.soknad.innsending.config.RestConfig
 import no.nav.soknad.innsending.consumerapis.pdl.PdlInterface
 import no.nav.soknad.innsending.consumerapis.pdl.dto.PersonDto
@@ -60,7 +59,6 @@ class InnsendingServiceTest : ApplicationTest() {
 	private lateinit var exceptionHelper: ExceptionHelper
 
 	val soknadsmottakerAPI = mockk<MottakerInterface>()
-	private val brukernotifikasjonPublisher = mockk<BrukernotifikasjonPublisher>()
 	private val pdlInterface = mockk<PdlInterface>()
 
 	@MockkBean
@@ -73,7 +71,6 @@ class InnsendingServiceTest : ApplicationTest() {
 		tilleggstonadService = tilleggstonadService,
 		ettersendingService = ettersendingService,
 		filService = filService,
-		brukernotifikasjonPublisher = brukernotifikasjonPublisher,
 		innsenderMetrics = innsenderMetrics,
 		exceptionHelper = exceptionHelper,
 		soknadsmottakerAPI = soknadsmottakerAPI,
@@ -83,7 +80,6 @@ class InnsendingServiceTest : ApplicationTest() {
 
 	@BeforeEach
 	fun setup() {
-		every { brukernotifikasjonPublisher.soknadStatusChange(any()) } returns true
 		every { pdlInterface.hentPersonData(any()) } returns PersonDto("1234567890", "Kan", null, "Søke")
 		every { subjectHandler.getClientId() } returns "application"
 	}

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/service/SoknadServiceTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/service/SoknadServiceTest.kt
@@ -5,7 +5,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import no.nav.soknad.innsending.ApplicationTest
-import no.nav.soknad.innsending.brukernotifikasjon.BrukernotifikasjonPublisher
 import no.nav.soknad.innsending.config.RestConfig
 import no.nav.soknad.innsending.consumerapis.pdl.PdlInterface
 import no.nav.soknad.innsending.consumerapis.pdl.dto.PersonDto
@@ -91,8 +90,6 @@ class SoknadServiceTest : ApplicationTest() {
 	@Autowired
 	private lateinit var restConfig: RestConfig
 
-	private val brukernotifikasjonPublisher = mockk<BrukernotifikasjonPublisher>()
-
 	private val hentSkjemaData = mockk<SkjemaClient>()
 
 	private val soknadsmottakerAPI = mockk<MottakerInterface>()
@@ -107,7 +104,6 @@ class SoknadServiceTest : ApplicationTest() {
 	@BeforeEach
 	fun setup() {
 		every { hentSkjemaData.hent() } returns hentSkjemaDataConsumer.initSkjemaDataFromDisk()
-		every { brukernotifikasjonPublisher.soknadStatusChange(any()) } returns true
 		every { pdlInterface.hentPersonData(any()) } returns PersonDto("1234567890", "Kan", null, "Søke")
 		every { subjectHandler.getClientId() } returns "application"
 	}
@@ -129,7 +125,6 @@ class SoknadServiceTest : ApplicationTest() {
 		tilleggstonadService = tilleggstonadService,
 		ettersendingService = ettersendingService,
 		filService = filService,
-		brukernotifikasjonPublisher = brukernotifikasjonPublisher,
 		innsenderMetrics = innsenderMetrics,
 		exceptionHelper = exceptionHelper,
 		soknadsmottakerAPI = soknadsmottakerAPI,
@@ -626,7 +621,7 @@ class SoknadServiceTest : ApplicationTest() {
 		val innsendingService = lagInnsendingService(soknadService)
 		// Check that reciept is returned for each sent in application
 		val kvitteringsDtoList = mutableListOf<KvitteringsDto>()
-		dokumentSoknadDtoList.forEach { kvitteringsDtoList.add(innsendingService.sendInnSoknad(it)) }
+		dokumentSoknadDtoList.forEach { kvitteringsDtoList.add(innsendingService.sendInnSoknad(it).first) }
 		assertTrue(kvitteringsDtoList.size == dokumentSoknadDtoList.size)
 
 		// Check that the applications attachments are kept after the applications are sent in

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/service/VedleggServiceTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/service/VedleggServiceTest.kt
@@ -4,7 +4,6 @@ import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.soknad.innsending.ApplicationTest
-import no.nav.soknad.innsending.brukernotifikasjon.BrukernotifikasjonPublisher
 import no.nav.soknad.innsending.exceptions.ExceptionHelper
 import no.nav.soknad.innsending.model.PatchVedleggDto
 import no.nav.soknad.innsending.model.PostVedleggDto
@@ -32,9 +31,6 @@ class VedleggServiceTest : ApplicationTest() {
 	private lateinit var vedleggService: VedleggService
 
 	@Autowired
-	private lateinit var ettersendingService: EttersendingService
-
-	@Autowired
 	private lateinit var filService: FilService
 
 	@Autowired
@@ -43,14 +39,11 @@ class VedleggServiceTest : ApplicationTest() {
 	@MockkBean
 	private lateinit var subjectHandler: SubjectHandlerInterface
 
-	private val brukernotifikasjonPublisher = mockk<BrukernotifikasjonPublisher>()
-
 	private fun lagSoknadService(): SoknadService = SoknadService(
 		skjemaService = skjemaService,
 		repo = repo,
 		vedleggService = vedleggService,
 		filService = filService,
-		brukernotifikasjonPublisher = brukernotifikasjonPublisher,
 		innsenderMetrics = innsenderMetrics,
 		exceptionHelper = exceptionHelper,
 		subjectHandler = subjectHandler,
@@ -58,7 +51,6 @@ class VedleggServiceTest : ApplicationTest() {
 
 	@BeforeEach
 	fun setup() {
-		every { brukernotifikasjonPublisher.soknadStatusChange(any()) } returns true
 		every { subjectHandler.getClientId() } returns "application"
 	}
 

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/service/unittest/LospostServiceTest.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/service/unittest/LospostServiceTest.kt
@@ -6,7 +6,6 @@ import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.slot
 import io.mockk.verify
-import no.nav.soknad.innsending.brukernotifikasjon.BrukernotifikasjonPublisher
 import no.nav.soknad.innsending.model.VisningsType
 import no.nav.soknad.innsending.repository.domain.models.SoknadDbData
 import no.nav.soknad.innsending.repository.domain.models.VedleggDbData
@@ -29,15 +28,11 @@ class LospostServiceTest {
 	@RelaxedMockK
 	lateinit var subjectHandler: SubjectHandlerInterface
 
-	@RelaxedMockK
-	lateinit var brukernotifikasjonPublisher: BrukernotifikasjonPublisher
-
 	@InjectMockKs
 	lateinit var lospostService: LospostService
 
 	@Test
 	fun `Should create one soknad and one vedlegg`() {
-
 		every { repo.lagreSoknad(any()) } answers {
 			val dto = firstArg<SoknadDbData>().copy(id = 1)
 			dto
@@ -46,8 +41,6 @@ class LospostServiceTest {
 			val dto = firstArg<VedleggDbData>().copy(id = 2)
 			dto
 		}
-
-		every { brukernotifikasjonPublisher.soknadStatusChange(any()) } returns true
 
 		val lospost = lospostService.saveLospostInnsending(
 			defaultUser,

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/utils/Api.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/utils/Api.kt
@@ -33,13 +33,16 @@ class Api(val restTemplate: TestRestTemplate, val serverPort: Int, val mockOAuth
 		return HttpEntity(body, Hjelpemetoder.createHeaders(token, map))
 	}
 
-	fun createSoknad(skjemaDto: SkjemaDto, forceCreate: Boolean = true): InnsendingApiResponse<SkjemaDto> {
+	fun createSoknad(skjemaDto: SkjemaDto, forceCreate: Boolean = true, envQualifier: EnvQualifier? = null): InnsendingApiResponse<SkjemaDto> {
+		val headers: Map<String, String>? = if (envQualifier != null) mapOf(
+			"Nav-Env-Qualifier" to envQualifier.value
+		) else null
 		val uri = UriComponentsBuilder.fromHttpUrl("${baseUrl}/fyllUt/v1/soknad")
 			.queryParam("force", forceCreate)
 			.build()
 			.toUri()
 
-		val response = restTemplate.exchange(uri, HttpMethod.POST, createHttpEntity(skjemaDto), String::class.java)
+		val response = restTemplate.exchange(uri, HttpMethod.POST, createHttpEntity(skjemaDto, headers), String::class.java)
 
 		val body = readBody(response, SkjemaDto::class.java)
 		return InnsendingApiResponse(response.statusCode, body, response.headers)
@@ -141,11 +144,14 @@ class Api(val restTemplate: TestRestTemplate, val serverPort: Int, val mockOAuth
 		)
 	}
 
-	fun sendInnSoknad(innsendingsId: String): InnsendingApiResponse<KvitteringsDto> {
+	fun sendInnSoknad(innsendingsId: String, envQualifier: EnvQualifier? = null): InnsendingApiResponse<KvitteringsDto> {
+		val headers: Map<String, String>? = if (envQualifier != null) mapOf(
+			"Nav-Env-Qualifier" to envQualifier.value
+		) else null
 		val response = restTemplate.exchange(
 			"${baseUrl}/frontend/v1/sendInn/${innsendingsId}",
 			HttpMethod.POST,
-			createHttpEntity(null),
+			createHttpEntity(null, headers),
 			String::class.java
 		)
 
@@ -199,11 +205,14 @@ class Api(val restTemplate: TestRestTemplate, val serverPort: Int, val mockOAuth
 		return Pair(null, errorBody)
 	}
 
-	fun createEttersending(opprettEttersending: OpprettEttersending): InnsendingApiResponse<DokumentSoknadDto> {
+	fun createEttersending(opprettEttersending: OpprettEttersending, envQualifier: EnvQualifier? = null): InnsendingApiResponse<DokumentSoknadDto> {
+		val headers: Map<String, String>? = if (envQualifier != null) mapOf(
+			"Nav-Env-Qualifier" to envQualifier.value
+		) else null
 		val response = restTemplate.exchange(
 			"${baseUrl}/fyllut/v1/ettersending",
 			HttpMethod.POST,
-			createHttpEntity(opprettEttersending),
+			createHttpEntity(opprettEttersending, headers),
 			String::class.java
 		)
 
@@ -211,11 +220,14 @@ class Api(val restTemplate: TestRestTemplate, val serverPort: Int, val mockOAuth
 		return InnsendingApiResponse(response.statusCode, body, response.headers)
 	}
 
-	fun createEksternEttersending(eksternOpprettEttersending: EksternOpprettEttersending): InnsendingApiResponse<DokumentSoknadDto> {
+	fun createEksternEttersending(eksternOpprettEttersending: EksternOpprettEttersending, envQualifier: EnvQualifier? = null): InnsendingApiResponse<DokumentSoknadDto> {
+		val headers: Map<String, String>? = if (envQualifier != null) mapOf(
+			"Nav-Env-Qualifier" to envQualifier.value
+		) else null
 		val response = restTemplate.exchange(
 			"${baseUrl}/ekstern/v1/ettersending",
 			HttpMethod.POST,
-			createHttpEntity(eksternOpprettEttersending),
+			createHttpEntity(eksternOpprettEttersending, headers),
 			String::class.java
 		)
 

--- a/innsender/src/test/kotlin/no/nav/soknad/innsending/utils/SoknadAssertions.kt
+++ b/innsender/src/test/kotlin/no/nav/soknad/innsending/utils/SoknadAssertions.kt
@@ -69,7 +69,7 @@ class SoknadAssertions {
 			val vedleggDtos2 = slot<List<VedleggDto>>()
 			every { soknadsmottakerAPI.sendInnSoknad(capture(soknad), capture(vedleggDtos2)) } returns Unit
 
-			val kvitteringsDto = innsendingService.sendInnSoknad(dokumentSoknadDto)
+			val (kvitteringsDto) = innsendingService.sendInnSoknad(dokumentSoknadDto)
 
 			Assertions.assertTrue(soknad.isCaptured)
 			Assertions.assertTrue(soknad.captured.innsendingsId == dokumentSoknadDto.innsendingsId)

--- a/innsender/src/test/resources/application-test.yml
+++ b/innsender/src/test/resources/application-test.yml
@@ -63,13 +63,7 @@ restconfig:
   soknadsMottakerHost: http://localhost:${wiremock.server.port}/soknadsmottaker-api
   soknadsMottakerEndpoint: /save
   sendInnUrl: http://localhost:3100/sendinn
-  sendinn:
-    urls:
-      default: http://localhost:3100/sendinn
   fyllUtUrl: http://localhost:3001/fyllut
-  fyllut:
-    urls:
-      default: http://localhost:3001/fyllut
   clientId: clientId
   clientSecret: clientSecret
   pdlScope: api://dev-fss.pdl.pdl-api/.default

--- a/innsender/src/test/resources/application-test.yml
+++ b/innsender/src/test/resources/application-test.yml
@@ -63,7 +63,13 @@ restconfig:
   soknadsMottakerHost: http://localhost:${wiremock.server.port}/soknadsmottaker-api
   soknadsMottakerEndpoint: /save
   sendInnUrl: http://localhost:3100/sendinn
+  sendinn:
+    urls:
+      default: http://localhost:3100/sendinn
   fyllUtUrl: http://localhost:3001/fyllut
+  fyllut:
+    urls:
+      default: http://localhost:3001/fyllut
   clientId: clientId
   clientSecret: clientSecret
   pdlScope: api://dev-fss.pdl.pdl-api/.default
@@ -77,9 +83,6 @@ restconfig:
   kontoregisterUrl: http://localhost:${wiremock.server.port}/kontoregister-api
 
 brukernotifikasjonconfig:
-  profiles: test
-  fyllutUrl: http://localhost:3001/fyllut
-  sendinnUrl: http://localhost:3100/sendinn
   publisereEndringer: true
 
 ettersendingsfrist: 14


### PR DESCRIPTION
- Refaktorering: Flytte opprettelse og avslutting av brukernotifikasjoner til rest-tjenestene
- Støtte envQualifier ved api-kall som kan føre til opprettelse av søknad eller en ettersending slik at url i brukernotifikasjon blir riktig